### PR TITLE
Fixes TextureRegion rendering upside down in Graphics

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.1.1]
+- Fixed Graphics rendering upside down TextureRegions.
+
 [1.1.0]
 - Updated to libGDX 1.6.4, roboVM 1.5.0 and reflections 0.9.10
 - Added isometric Tiled map support

--- a/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
+++ b/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
@@ -358,8 +358,11 @@ public class Graphics {
 	 *            texture if not matching the region's height)
 	 */
 	public void drawTextureRegion(TextureRegion textureRegion, float x, float y, float width, float height) {
+		if (!textureRegion.isFlipY()) {
+			textureRegion.flip(false, true);
+		}
 		beginRendering();
-		spriteBatch.draw(textureRegion, x, y + height, 0f, 0f, width, -height, 1f, 1f, 0f);
+		spriteBatch.draw(textureRegion, x, y, 0f, 0f, width, height, 1f, 1f, 0f);
 	}
 
 	/**

--- a/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
+++ b/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
@@ -358,11 +358,8 @@ public class Graphics {
 	 *            texture if not matching the region's height)
 	 */
 	public void drawTextureRegion(TextureRegion textureRegion, float x, float y, float width, float height) {
-		if (!textureRegion.isFlipY()) {
-			textureRegion.flip(false, true);
-		}
 		beginRendering();
-		spriteBatch.draw(textureRegion, x, y, 0f, 0f, width, height, 1f, 1f, 0f);
+		spriteBatch.draw(textureRegion, x, y + height, 0f, 0f, width, -height, 1f, 1f, 0f);
 	}
 
 	/**

--- a/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
+++ b/core/src/main/java/org/mini2Dx/core/graphics/Graphics.java
@@ -359,7 +359,7 @@ public class Graphics {
 	 */
 	public void drawTextureRegion(TextureRegion textureRegion, float x, float y, float width, float height) {
 		beginRendering();
-		spriteBatch.draw(textureRegion, x, y, 0f, 0f, width, height, 1f, 1f, 0f);
+		spriteBatch.draw(textureRegion, x, y + height, 0f, 0f, width, -height, 1f, 1f, 0f);
 	}
 
 	/**


### PR DESCRIPTION
As pointed out in issue #35, TextureRegions were rendered upside down when using `Graphics.drawTextureRegion` method. A `Sprite` could be used to flip the region but since normal textures can already be rendered not-upside down without creating any wrapping Sprite, I thought that I could give a try to fixing `TextureRegion` too.

It turns out that TextureRegion already has a `flip` method so what I did was to test whether the region was already flipped and if it wasn't, to flip it. Previously I used an ugly hack which is passing a negative height into SpriteBatch, but this is not as easy to see as flipping the region.

I made some regression checks by creating a few Sprites using TextureRegions and they still render OK since they use a different rendering method.