### PR TITLE
Feature/artemis upgrade

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 [1.3.0-alpha]
-- Updated to libGDX 1.7.0 and roboVM 1.8.0
+- Updated to libGDX 1.7.0, roboVM 1.8.0, and artemis-odb 1.1.0
 - Updated to Android build tools 23.0.1
 - Added controller mappings - Xbox One, Xbox 360 controllers
 - Added render pipeline feature

--- a/artemis-odb/src/main/java/com/artemis/MdxInvocationStrategy.java
+++ b/artemis-odb/src/main/java/com/artemis/MdxInvocationStrategy.java
@@ -26,9 +26,6 @@ public class MdxInvocationStrategy extends InvocationStrategy {
 		Object[] systems = systemsBag.getData();
 		for (int i = 0, s = systemsBag.size(); s > i; i++) {
 			InterpolatingEntitySystem system = (InterpolatingEntitySystem) systems[i];
-			if (system.isPassive()) {
-				continue;
-			}
 			system.interpolateSystem();
 		}
 	}
@@ -37,9 +34,6 @@ public class MdxInvocationStrategy extends InvocationStrategy {
 		Object[] systems = systemsBag.getData();
 		for (int i = 0, s = systemsBag.size(); s > i; i++) {
 			RenderingEntitySystem system = (RenderingEntitySystem) systems[i];
-			if (system.isPassive()) {
-				continue;
-			}
 			system.renderSystem(g);
 		}
 	}

--- a/artemis-odb/src/main/java/com/artemis/system/InterpolatingEntitySystem.java
+++ b/artemis-odb/src/main/java/com/artemis/system/InterpolatingEntitySystem.java
@@ -23,7 +23,6 @@ import com.artemis.utils.IntBag;
  * Implements {@link EntitySystem} to add mini2Dx's update/interpolate methods
  */
 public abstract class InterpolatingEntitySystem extends EntitySystem {
-	private Entity flyweight;
 	private MdxWorld mdxWorld;
 	
 	private IntBag activeEntityBag;
@@ -37,18 +36,16 @@ public abstract class InterpolatingEntitySystem extends EntitySystem {
 		super(aspect);
 	}
 	
-	protected abstract void update(Entity e, float delta);
+	protected abstract void update(int entityId, float delta);
 	
-	protected abstract void interpolate(Entity e, float alpha);
+	protected abstract void interpolate(int entityId, float alpha);
 
 	@Override
 	protected void processSystem() {
 		activeEntityBag = subscription.getEntities();
 		activeEntityIds = activeEntityBag.getData();
-		Entity e = flyweight;
 		for (int i = 0, s = activeEntityBag.size(); s > i; i++) {
-			e.id = activeEntityIds[i];
-			update(e, world.delta);
+			update(activeEntityIds[i], world.delta);
 		}
 	}
 	
@@ -60,18 +57,15 @@ public abstract class InterpolatingEntitySystem extends EntitySystem {
 			return;
 		}
 		
-		Entity e = flyweight;
 		for (int i = 0, s = activeEntityBag.size(); s > i; i++) {
-			e.id = activeEntityIds[i];
-			interpolate(e, mdxWorld.alpha);
+			interpolate(activeEntityIds[i], mdxWorld.alpha);
 		}
 	}
 	
 	@Override
 	public void setWorld(World world) {
 		super.setWorld(world);
-		flyweight = createFlyweightEntity();
-		
+
 		if(world instanceof MdxWorld) {
 			this.mdxWorld = (MdxWorld) world;
 		}

--- a/artemis-odb/src/main/java/com/artemis/system/RenderingEntitySystem.java
+++ b/artemis-odb/src/main/java/com/artemis/system/RenderingEntitySystem.java
@@ -25,7 +25,6 @@ import com.artemis.utils.IntBag;
  * Implements {@link EntitySystem} to add mini2Dx's render method
  */
 public abstract class RenderingEntitySystem extends EntitySystem {
-	private Entity flyweight;
 	private MdxWorld mdxWorld;
 	
 	private IntBag activeEntityBag;
@@ -39,7 +38,7 @@ public abstract class RenderingEntitySystem extends EntitySystem {
 		super(aspect);
 	}
 	
-	protected abstract void render(Entity e, Graphics g);
+	protected abstract void render(int entityId, Graphics g);
 
 	@Override
 	protected void processSystem() {
@@ -55,18 +54,15 @@ public abstract class RenderingEntitySystem extends EntitySystem {
 			return;
 		}
 		
-		Entity e = flyweight;
 		for (int i = 0, s = activeEntityBag.size(); s > i; i++) {
-			e.id = activeEntityIds[i];
-			render(e, g);
+			render(activeEntityIds[i], g);
 		}
 	}
 	
 	@Override
 	public void setWorld(World world) {
 		super.setWorld(world);
-		flyweight = createFlyweightEntity();
-		
+
 		if(world instanceof MdxWorld) {
 			this.mdxWorld = (MdxWorld) world;
 		}

--- a/artemis-odb/src/test/java/com/artemis/system/InterpolatingEntitySystemTest.java
+++ b/artemis-odb/src/test/java/com/artemis/system/InterpolatingEntitySystemTest.java
@@ -63,8 +63,8 @@ public class InterpolatingEntitySystemTest extends InterpolatingEntitySystem {
 		
 		world.process();
 		
-		Assert.assertEquals(true, updatedIds.contains(entityWithComponent.id));
-		Assert.assertEquals(false, updatedIds.contains(entityWithoutComponent.id));
+		Assert.assertEquals(true, updatedIds.contains(entityWithComponent.getId()));
+		Assert.assertEquals(false, updatedIds.contains(entityWithoutComponent.getId()));
 	}
 	
 	@Test
@@ -87,8 +87,8 @@ public class InterpolatingEntitySystemTest extends InterpolatingEntitySystem {
 		world.process();
 		world.interpolate();
 		
-		Assert.assertEquals(true, interpolatedIds.contains(entityWithComponent.id));
-		Assert.assertEquals(false, interpolatedIds.contains(entityWithoutComponent.id));
+		Assert.assertEquals(true, interpolatedIds.contains(entityWithComponent.getId()));
+		Assert.assertEquals(false, interpolatedIds.contains(entityWithoutComponent.getId()));
 	}
 	
 	@Test
@@ -110,14 +110,14 @@ public class InterpolatingEntitySystemTest extends InterpolatingEntitySystem {
 	}
 
 	@Override
-	protected void update(Entity e, float delta) {
-		updatedIds.add(e.id);
+	protected void update(int entityId, float delta) {
+		updatedIds.add(entityId);
 		Assert.assertEquals(expectedDelta, delta);
 	}
 
 	@Override
-	protected void interpolate(Entity e, float alpha) {
-		interpolatedIds.add(e.id);
+	protected void interpolate(int entityId, float alpha) {
+		interpolatedIds.add(entityId);
 		Assert.assertEquals(expectedAlpha, alpha);
 	}
 }

--- a/artemis-odb/src/test/java/com/artemis/system/RenderingEntitySystemTest.java
+++ b/artemis-odb/src/test/java/com/artemis/system/RenderingEntitySystemTest.java
@@ -68,8 +68,8 @@ public class RenderingEntitySystemTest extends RenderingEntitySystem {
 		world.process();
 		world.render(graphics);
 		
-		Assert.assertEquals(true, renderedIds.contains(entityWithComponent.id));
-		Assert.assertEquals(false, renderedIds.contains(entityWithoutComponent.id));
+		Assert.assertEquals(true, renderedIds.contains(entityWithComponent.getId()));
+		Assert.assertEquals(false, renderedIds.contains(entityWithoutComponent.getId()));
 	}
 	
 	@Test
@@ -89,8 +89,8 @@ public class RenderingEntitySystemTest extends RenderingEntitySystem {
 	}
 
 	@Override
-	protected void render(Entity e, Graphics g) {
-		renderedIds.add(e.id);
+	protected void render(int entityId, Graphics g) {
+		renderedIds.add(entityId);
 		Assert.assertEquals(graphics, g);
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
 		beanutilsVersion="1.8.3"
 		langVersion="3.1"
 		reflectionsVersion="0.9.10"
-		artemisVersion="0.11.3"
+		artemisVersion="1.1.0"
 		
 		junitVersion="4.8.1"
 		jmockVersion="2.5.1"


### PR DESCRIPTION
Updated artemis to the latest version.

Note that this is a breaking change. The flyweight entity model is no longer used in the 1.0.0 version of artemis-odb, as such, either we incur a breaking change to upgrade to the latest artemis version or we downgrade to the fallback version that creates entities for every id.

Given that this is post-1.0.0 of artemis-odb, I doubt this area will be breaking again in the future. Again, this is a breaking change.

The latest versions of artemis do provide some very useful dependency injection patterns that I'd like to use.
