### PR TITLE
Minor fix to HeadlessMini2DxGame

### DIFF
--- a/headless/src/main/java/com/badlogic/gdx/backends/headless/HeadlessMini2DxGame.java
+++ b/headless/src/main/java/com/badlogic/gdx/backends/headless/HeadlessMini2DxGame.java
@@ -206,7 +206,7 @@ public class HeadlessMini2DxGame implements Application {
 
 	@Override
 	public ApplicationType getType() {
-		return ApplicationType.Desktop;
+		return ApplicationType.HeadlessDesktop;
 	}
 
 	@Override


### PR DESCRIPTION
Set correct ApplicationType. Useful to detect in game-core in which application type its run.