### PR TITLE
Implemented internal Files API

### DIFF
--- a/monogame/Files/MonoGameFileHandle.cs
+++ b/monogame/Files/MonoGameFileHandle.cs
@@ -1,0 +1,596 @@
+/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using java.io;
+using monogame.Util;
+using org.mini2Dx.core.files;
+using File = System.IO.File;
+using IOException = java.io.IOException;
+
+namespace monogame.Files
+{
+    public class MonoGameFileHandle : FileHandle
+    {
+        private readonly FileType _fileType;
+        private readonly FileInfo _fileInfo;
+        private DirectoryInfo _directoryInfo;
+        private bool _isDirectory;
+        
+        public MonoGameFileHandle(string path, FileType fileType)
+        {
+            _fileType = fileType;
+            _isDirectory = (File.GetAttributes(path) & FileAttributes.Directory) != 0;
+            if (_isDirectory)
+            {
+                _directoryInfo = new DirectoryInfo(path);
+            }
+            else
+            {
+                _fileInfo = new FileInfo(path);
+            }
+        }
+
+        public string fullPath()
+        {
+            return (isDirectory() ? (object) _directoryInfo : _fileInfo).ToString();
+        }
+        
+        public string path()
+        {
+            return _fileType == FileType.INTERNAL ? fullPath().Remove(0, MonoGameFiles.InternalFilePrefix.Length) : fullPath();
+        }
+
+        public string normalize()
+        {
+            throw new NotImplementedException(); //You can't normalize a path in C#, see dotnet/corefx#30701 and dotnet/corefx#4208.
+        }
+
+        public string name()
+        {
+            return _isDirectory ? _directoryInfo.Name : _fileInfo.Name;
+        }
+
+        public string extension()
+        {
+            return _isDirectory ? "" : name().Remove(0, name().LastIndexOf('.')+1);
+        }
+
+        public string nameWithoutExtension()
+        {
+            return _isDirectory ? _directoryInfo.Name : name().Substring(0, name().LastIndexOf('.'));
+        }
+
+        public string pathWithoutExtension()
+        {
+            return _isDirectory ? _directoryInfo.ToString() : path().Substring(0, path().LastIndexOf('.'));
+        }
+
+        public FileType type()
+        {
+            return _fileType;
+        }
+
+        public InputStream read()
+        {
+            return new MonoGameInputStream(this);
+        }
+
+        public BufferedInputStream read(int i)
+        {
+            return new BufferedInputStream(read(), i);
+        }
+
+        public Reader reader()
+        {
+            return new InputStreamReader(read());
+        }
+
+        public Reader reader(string encoding)
+        {
+            return new InputStreamReader(read(), encoding);
+        }
+
+        public BufferedReader reader(int bufferSize)
+        {
+            return new BufferedReader(reader(), bufferSize);
+        }
+
+        public BufferedReader reader(int bufferSize, string encoding)
+        {
+            return new BufferedReader(reader(encoding), bufferSize);
+        }
+
+        public string readString()
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read from a directory");
+            }
+
+            return File.ReadAllText(fullPath());
+        }
+
+        public string readString(string encoding)
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read from a directory");
+            }
+
+            return File.ReadAllText(fullPath(), Encoding.GetEncoding(encoding));
+        }
+
+        public byte[] readBytes()
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read from a directory");
+            }
+
+            var fileBytes = new byte[_fileInfo.Length];
+
+            readBytes(fileBytes, 0, (int) _fileInfo.Length);
+
+            return fileBytes;
+        }
+
+        public int readBytes(byte[] fileBytes, int offset, int size)
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read from a directory");
+            }
+
+            var readBytesNumber = 0;
+            using (var byteStream = _fileInfo.OpenRead())
+            {
+                for (var i = offset; i < offset + size; i++)
+                {
+                    var readByte = byteStream.ReadByte();
+                    if (readByte == -1)
+                    {
+                        break;
+                    }
+
+                    fileBytes[i] = (byte) readByte;
+                    readBytesNumber++;
+                }
+            }
+
+            return readBytesNumber;
+        }
+
+        public OutputStream write(bool append)
+        {
+            return new MonoGameOutputStream(this, append);
+        }
+
+        public OutputStream write(bool append, int bufferSize)
+        {
+            return new BufferedOutputStream(write(append), bufferSize);
+        }
+
+        public Writer writer(bool append)
+        {
+            return new OutputStreamWriter(write(append));
+        }
+
+        public Writer writer(bool append, string encoding)
+        {
+            return new OutputStreamWriter(write(append), encoding);
+        }
+
+        public void writeString(string str, bool append)
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read write to directory");
+            }
+
+            if (type() == FileType.INTERNAL)
+            {
+                throw new IOException("Can't write in an INTERNAL file");
+            }
+
+            if (append)
+            {
+                File.AppendAllText(fullPath(), str);
+            }
+            else
+            {
+                File.WriteAllText(fullPath(), str);
+            }
+        }
+
+        public void writeString(string str, bool append, string encoding)
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read write to directory");
+            }
+
+            if (type() == FileType.INTERNAL)
+            {
+                throw new IOException("Can't write in an INTERNAL file");
+            }
+
+            if (append)
+            {
+                File.AppendAllText(fullPath(), str, Encoding.GetEncoding(encoding));
+            }
+            else
+            {
+                File.WriteAllText(fullPath(), str, Encoding.GetEncoding(encoding));
+            }
+        }
+
+        public void writeBytes(byte[] bytes, bool append)
+        {
+            writeBytes(bytes, 0, bytes.Length, append);
+        }
+
+        public void writeBytes(byte[] bytes, int offset, int size, bool append)
+        {
+            if (_isDirectory)
+            {
+                throw new IOException("Can't read write to directory");
+            }
+
+            if (type() == FileType.INTERNAL)
+            {
+                throw new IOException("Can't write in an INTERNAL file");
+            }
+
+            var fileStream = new FileStream(fullPath(), append ? FileMode.Append : FileMode.OpenOrCreate, FileAccess.Write);
+            fileStream.Seek(offset, SeekOrigin.Begin);
+            using (var streamWriter = new StreamWriter(fileStream))
+            {
+                for (var i = offset; i < offset + size; i++)
+                {
+                    streamWriter.Write(bytes[i]);
+                }
+            }
+        }
+
+        public FileHandle[] list()
+        {
+            return list("");
+        }
+
+        public FileHandle[] list(string suffix)
+        {
+            if (!_isDirectory || _fileType == FileType.INTERNAL)
+                return new FileHandle[0];
+            var matchingChilds = new List<FileHandle>();
+            var childFiles = _directoryInfo.GetFiles();
+            var childDirs = _directoryInfo.GetDirectories();
+
+            //Not using foreach or LINQ query because they could be as much as 10x slower.
+            
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var i = 0; i < childFiles.Length; i++)
+            {
+                var child = childFiles[i];
+                if (child.Name.EndsWith(suffix))
+                {
+                    matchingChilds.Add(new MonoGameFileHandle(child.ToString(), _fileType));
+                }
+            }
+
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var i = 0; i < childDirs.Length; i++)
+            {
+                var child = childDirs[i];
+                if (child.Name.EndsWith(suffix))
+                {
+                    matchingChilds.Add(new MonoGameFileHandle(child.ToString(), _fileType));
+                }
+            }
+
+            return matchingChilds.ToArray();
+        }
+
+        public bool isDirectory()
+        {
+            return _isDirectory;
+        }
+
+        public FileHandle child(string name)
+        {
+            return new MonoGameFileHandle(Path.Combine(fullPath(),  name), _fileType);
+        }
+
+        public FileHandle sibling(string name)
+        {
+            return parent().child(name);
+        }
+
+        public FileHandle parent()
+        {
+            return new MonoGameFileHandle((_isDirectory ? _directoryInfo.Parent : _fileInfo.Directory).ToString(), _fileType);
+        }
+
+        public void mkdirs()
+        {
+            if (_fileType == FileType.INTERNAL)
+            {
+                throw new IOException("You can't mkdirs() an INTERNAL file");
+            }
+
+            _directoryInfo = Directory.CreateDirectory(_fileInfo.ToString());
+            _isDirectory = true;
+        }
+
+        public bool exists()
+        {
+            return _isDirectory ? _directoryInfo.Exists : _fileInfo.Exists;
+        }
+
+        public bool delete()
+        {
+            if (_fileType == FileType.INTERNAL)
+            {
+                throw new IOException("You can't delete() an INTERNAL file");
+            }
+
+            if (_isDirectory)
+            {
+                if (_directoryInfo.GetDirectories().Length + _directoryInfo.GetFiles().Length != 0)
+                {
+                    return false;
+                }
+
+                _directoryInfo.Delete();
+            }
+            else
+            {
+                _fileInfo.Delete();
+            }
+
+            return true;
+        }
+
+        public bool deleteDirectory()
+        {
+            if (_fileType == FileType.INTERNAL)
+            {
+                throw new IOException("You can't deleteDirectory() an INTERNAL file");
+            }
+
+            if (_isDirectory)
+            {
+                try
+                {
+                    _directoryInfo.Delete(true);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                try
+                {
+                    _fileInfo.Delete();
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public void emptyDirectory()
+        {
+            if (_fileType == FileType.INTERNAL)
+            {
+                throw new IOException("You can't emptyDirectory() an INTERNAL file");
+            }
+
+            emptyDirectory(false);
+        }
+
+        public void emptyDirectory(bool preserveTree)
+        {
+            if (_fileType == FileType.INTERNAL)
+            {
+                throw new IOException("You can't emptyDirectory() an INTERNAL file");
+            }
+
+            foreach (var child in list())
+            {
+                if (!preserveTree)
+                {
+                    child.deleteDirectory();
+                }
+                else
+                {
+                    if (child.isDirectory())
+                    {
+                        child.emptyDirectory(false);
+                    }
+                    else
+                    {
+                        child.delete();
+                    }
+                }
+            }
+        }
+
+        //https://stackoverflow.com/a/690980
+        private static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        {
+            Directory.CreateDirectory(target.FullName);
+            
+            var files = source.GetFiles();
+            for (var i = 0; i < files.Length; i++)
+            {
+                var fileInfo = files[i];
+                fileInfo.CopyTo(Path.Combine(target.FullName, fileInfo.Name), true);
+            }
+
+            var subdirectories = source.GetDirectories();
+            for (var i = 0; i < subdirectories.Length; i++)
+            {
+                var subdirectoryInfo = subdirectories[i];
+                var nextTargetSubDir = target.CreateSubdirectory(subdirectoryInfo.Name);
+                CopyAll(subdirectoryInfo, nextTargetSubDir);
+            }
+        }
+
+        public void copyTo(FileHandle dest)
+        {
+            if (dest.type() == FileType.INTERNAL)
+            {
+                throw new IOException();
+            }
+
+            if (_isDirectory)
+            {
+                if (dest.exists() && !dest.isDirectory())
+                {
+                    throw new IOException();
+                }
+
+                CopyAll(_directoryInfo, ((MonoGameFileHandle)dest)._directoryInfo);
+            }
+            else
+            {
+                if (dest.exists())
+                {
+                    if (dest.isDirectory())
+                    {
+                        
+                        _fileInfo.CopyTo(((MonoGameFileHandle)dest.child(name())).fullPath(), true);
+                    }
+                    else
+                    {
+                        _fileInfo.CopyTo(((MonoGameFileHandle) dest).fullPath(), true);
+                    }
+                }
+                else
+                {
+                    dest.parent().mkdirs();
+                    
+                    _fileInfo.CopyTo(((MonoGameFileHandle) dest)._fileInfo.ToString(), true);
+                }
+            }
+        }
+
+        public void moveTo(FileHandle dest)
+        {
+            if (_fileType == FileType.INTERNAL || dest.type() == FileType.INTERNAL)
+            {
+                throw new IOException("You can't moveTo() an INTERNAL file");
+            }
+
+            if (dest.exists())
+            {
+                dest.deleteDirectory();
+            }
+
+            if (_isDirectory)
+            {
+                _directoryInfo.MoveTo(dest.ToString());
+            }
+            else
+            {
+                _fileInfo.MoveTo(dest.ToString());
+            }
+        }
+
+        public long length()
+        {
+            return _isDirectory ? 0 : _fileInfo.Length;
+        }
+
+        public long lastModified()
+        {
+            if (_fileType == FileType.INTERNAL || !exists())
+            {
+                return 0;
+            }
+
+            return _isDirectory ? DateTimeToTotalMs(_directoryInfo.LastWriteTimeUtc) : DateTimeToTotalMs(_fileInfo.LastWriteTimeUtc);
+        }
+
+        public FileHandle[] list(FilenameFilter filter)
+        {
+            var matchingChilds = new List<FileHandle>();
+
+            var childs = list();
+
+            //Not using foreach or LINQ query because they could be as much as 10x slower.
+            
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var i = 0; i < childs.Length; i++)
+            {
+                if (filter.accept(new java.io.File(fullPath()), childs[i].name()))
+                {
+                    matchingChilds.Add(childs[i]);
+                }
+            }
+
+            return matchingChilds.ToArray();
+        }
+
+        public FileHandle[] list(FileFilter filter)
+        {
+            var matchingChilds = new List<FileHandle>();
+
+            var childs = list();
+
+            //Not using foreach or LINQ query because they could be as much as 10x slower.
+            
+            // ReSharper disable once ForCanBeConvertedToForeach
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            for (var i = 0; i < childs.Length; i++)
+            {
+                if (filter.accept(new java.io.File(((MonoGameFileHandle) childs[i]).fullPath())))
+                {
+                    matchingChilds.Add(childs[i]);
+                }
+            }
+
+            return matchingChilds.ToArray();
+        }
+
+        public void write(InputStream inputStream, bool append)
+        {
+            var outputStream = write(append);
+            var read = inputStream.read();
+            while (read != -1)
+            {
+                outputStream.write(read);
+                read = inputStream.read();
+            }
+        }
+
+        private static long DateTimeToTotalMs(DateTime dateTime)
+        {
+            return dateTime.Subtract(new DateTime(1970, 1, 1)).Ticks / TimeSpan.TicksPerMillisecond;
+        }
+    }
+}

--- a/monogame/Graphics/MonoGamePixmap.cs
+++ b/monogame/Graphics/MonoGamePixmap.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/monogame/Graphics/MonoGameTexture.cs
+++ b/monogame/Graphics/MonoGameTexture.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 using Microsoft.Xna.Framework.Graphics;
 using org.mini2Dx.core.graphics;
 
@@ -22,7 +33,7 @@ namespace monogame.Graphics
             texture2D.Dispose();
         }
 
-        public void draw(Pixmap p, int i1, int i2)
+        public void draw(Pixmap pixmap, int x, int y)
         {
             
         }

--- a/monogame/MonoGameAudio.cs
+++ b/monogame/MonoGameAudio.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/monogame/MonoGameFiles.cs
+++ b/monogame/MonoGameFiles.cs
@@ -1,14 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
+using System.IO;
+using monogame.Files;
 using org.mini2Dx.core.files;
 
 namespace monogame
 {
-    class MonoGameFiles : org.mini2Dx.core.Files
+    public class MonoGameFiles : org.mini2Dx.core.Files
     {
+        public static readonly string InternalFilePrefix = "Content" + Path.DirectorySeparatorChar;
         public FileHandle external(string path)
         {
             throw new NotImplementedException();
@@ -16,17 +30,17 @@ namespace monogame
 
         public FileHandle @internal(string path)
         {
-            throw new NotImplementedException();
+            return new MonoGameFileHandle(InternalFilePrefix + path, FileType.INTERNAL);
         }
 
         public bool isExternalStorageAvailable()
         {
-            throw new NotImplementedException();
+            return false;
         }
 
         public bool isLocalStorageAvailable()
         {
-            throw new NotImplementedException();
+            return false;
         }
 
         public FileHandle local(string path)

--- a/monogame/MonoGameGraphics.cs
+++ b/monogame/MonoGameGraphics.cs
@@ -1,4 +1,19 @@
-﻿using org.mini2Dx.core;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 using org.mini2Dx.core.font;
 using org.mini2Dx.core.geom;
 using org.mini2Dx.core.graphics;

--- a/monogame/MonoGameGraphicsUtils.cs
+++ b/monogame/MonoGameGraphicsUtils.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
 using org.mini2Dx.core.files;
 using org.mini2Dx.core.graphics;
 

--- a/monogame/MonoGameInput.cs
+++ b/monogame/MonoGameInput.cs
@@ -1,8 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
 using org.mini2Dx.gdx;
 
 namespace monogame

--- a/monogame/Util/MonoGameInputStream.cs
+++ b/monogame/Util/MonoGameInputStream.cs
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System;
+using System.IO;
+using monogame.Files;
+using IOException = java.io.IOException;
+
+namespace monogame.Util
+{
+    //adapted from http://hg.openjdk.java.net/jdk10/jdk10/jdk/file/777356696811/src/java.base/share/classes/java/io/InputStream.java
+    public class MonoGameInputStream : java.io.InputStream
+    {
+        private readonly Stream _stream;
+        private const int MaxSkipBufferSize = 2048;
+        
+        public MonoGameInputStream(MonoGameFileHandle fileHandle)
+        {
+            if (!fileHandle.exists() || fileHandle.isDirectory())
+            {
+                throw new IOException();
+            }
+
+            var fileInfo = new FileInfo(fileHandle.fullPath());
+            _stream = fileInfo.OpenRead();
+        }
+        
+        public override int read()
+        {
+            return _stream.ReadByte();
+        }
+
+        public override int read(byte[] b, int off, int len)
+        {
+            if (len == 0)
+            {
+                return 0;
+            }
+
+            var c = read();
+            if (c == -1)
+            {
+                return -1;
+            }
+
+            b[off] = (byte) c;
+            var i = 1;
+            try
+            {
+                for (; i < len; i++)
+                {
+                    c = read();
+                    if (c == -1)
+                    {
+                        break;
+                    }
+
+                    b[off + i] = (byte) c;
+                }
+            }
+            catch (IOException)
+            {
+            }
+            return i;
+        }
+
+        public override int read(byte[] b)
+        {
+            return read(b, 0, b.Length);
+        }
+
+        public override long skip(long n)
+        {
+            var remaining = n;
+            if (n <= 0)
+            {
+                return 0;
+            }
+
+            var size = (int) Math.Min(MaxSkipBufferSize, remaining);
+            var skipBuffer = new byte[size];
+            while (remaining > 0)
+            {
+                var nr = read(skipBuffer, 0, (int) Math.Min(size, remaining));
+                if (nr < 0)
+                {
+                    break;
+                }
+
+                remaining -= nr;
+            }
+            return n - remaining;
+        }
+
+        public override int available()
+        {
+            return 0;
+        }
+
+        public override void close()
+        {
+            _stream.Close();
+        }
+
+        public override void mark(int readLimit)
+        {
+        }
+
+        public override void reset()
+        {
+            throw new IOException("mark/reset aren't supported");
+        }
+
+        public override bool markSupported()
+        {
+            return false;
+        }
+    }
+}

--- a/monogame/Util/MonoGameOutputStream.cs
+++ b/monogame/Util/MonoGameOutputStream.cs
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+using System.IO;
+using java.lang;
+using monogame.Files;
+
+namespace monogame.Util
+{
+    //adapted from http://hg.openjdk.java.net/jdk10/jdk10/jdk/file/777356696811/src/java.base/share/classes/java/io/OutputStream.java
+    public class MonoGameOutputStream : java.io.OutputStream
+    {
+        
+        private readonly Stream _stream;
+        
+        public MonoGameOutputStream(MonoGameFileHandle fileHandle, bool append)
+        {
+            if (!fileHandle.exists() || fileHandle.isDirectory()) throw new IOException();
+            var fileInfo = new FileInfo(fileHandle.fullPath());
+            _stream = append ? fileInfo.Open(FileMode.Append, FileAccess.Write) : fileInfo.Create();
+        }
+        
+        public override void write(int b)
+        {
+            _stream.WriteByte((byte) b);
+        }
+
+        public override void write(byte[] b, int off, int len)
+        {
+            if (b == null)
+                throw new NullPointerException();
+            if ((off < 0) || (off > b.Length) || (len < 0) || ((off + len) > b.Length) || ((off + len) < 0))
+                throw new IndexOutOfBoundsException();
+            if (len == 0)
+                return;
+            for (var i = 0; i < len; i++)
+            {
+                write(b[off + i]);
+            }
+        }
+
+        public override void write(byte[] b)
+        {
+            write(b,0, b.Length);
+        }
+
+        public override void close()
+        {
+            _stream.Close();
+        }
+
+        public override void flush()
+        {
+            _stream.Flush();
+        }
+    }
+}

--- a/monogame/mini2Dx-monogame.csproj
+++ b/monogame/mini2Dx-monogame.csproj
@@ -32,6 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IKVM.OpenJDK.Core, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58">
+      <HintPath>..\_tools\ikvm\bin\IKVM.OpenJDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="IKVM.Runtime, Version=8.1.5717.0, Culture=neutral, PublicKeyToken=13235d27fcbfff58">
+      <HintPath>..\_tools\ikvm\bin\IKVM.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="mini2Dx-core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\core\build\libs\mini2Dx-core.dll</HintPath>
     </Reference>
@@ -41,12 +47,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Files\MonoGameFileHandle.cs" />
+    <Compile Include="Graphics\MonoGamePixmap.cs" />
+    <Compile Include="Graphics\MonoGameTexture.cs" />
     <Compile Include="MonoGameAudio.cs" />
     <Compile Include="MonoGameFiles.cs" />
     <Compile Include="MonoGameGraphics.cs" />
     <Compile Include="MonoGameGraphicsUtils.cs" />
     <Compile Include="MonoGameInput.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\MonoGameInputStream.cs" />
+    <Compile Include="Util\MonoGameOutputStream.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.Portable">

--- a/uats-monogame/Game1.cs
+++ b/uats-monogame/Game1.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Xna.Framework;
+﻿using System;
+using System.IO.IsolatedStorage;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 
@@ -27,7 +29,8 @@ namespace uats_monogame
         protected override void Initialize()
         {
             // TODO: Add your initialization logic here
-
+            IsolatedStorageFile isolatedStorageFile = IsolatedStorageFile.GetUserStoreForDomain();
+            Console.WriteLine(isolatedStorageFile.AvailableFreeSpace);
             base.Initialize();
         }
 

--- a/uats-monogame/mini2Dx-uats-monogame.csproj
+++ b/uats-monogame/mini2Dx-uats-monogame.csproj
@@ -14,6 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <MonoGamePlatform>DesktopGL</MonoGamePlatform>
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Below there are the messages of the 19 squashed commits

Included some necessary assemblies

Initial implementation of the files API

Implemented InputStream and OutputStream utility classes based on jdk10 classes

Added InputStream and OutputStream capabilities to FileHandle
Now the list(string) method is using for loops instead of foreach for performance reasons
DataTimeToTotalMs is now static
Fixed readBytes(byte[], int, int) behaviour, now it reads until -1 is returned (previously it was incorrectly 0)

Fixed internal FileHandle getter
Used the platform independent Path.DirectorySeparatorChar instead of the /

Inverted a wrong if-else statement in MonoGameFileHandle constructor
Fixed MonoGameFileHandle.path() behaviour
Added MonoGameFileHandle.fullPath() which has the old behaviour of path()
Removed MonoGameFileHandle.normalize() method because you can't normalize a path in c#
Fixed MonoGameFileHandle.extension(), now it correctly removes the '.' before the extension

Now the MonoGameInputStream constructor takes a MonoGameFileHandle instead of a FileHandle
Now the MonoGameOutputStream constructor takes a MonoGameFileHandle instead of a FileHandle

Improved MonoGameFiles readability

Added a description to the IOException thrown by MonoGameInputStream.reset()

Finished implemeting MonoGameFileHandle