### PR TITLE
Removed useMipMaps from GraphicsUtils

### DIFF
--- a/core/src/main/java/org/mini2Dx/core/GraphicsUtils.java
+++ b/core/src/main/java/org/mini2Dx/core/GraphicsUtils.java
@@ -36,15 +36,11 @@ public interface GraphicsUtils {
 
 	public Texture newTexture(FileHandle file);
 
-	public Texture newTexture(FileHandle file, boolean useMipMaps);
-
-	public Texture newTexture(FileHandle file, PixmapFormat format, boolean useMipMaps);
+	public Texture newTexture(FileHandle file, PixmapFormat format);
 
 	public Texture newTexture(Pixmap pixmap);
 
-	public Texture newTexture(Pixmap pixmap, boolean useMipMaps);
-
-	public Texture newTexture(Pixmap pixmap, PixmapFormat format, boolean useMipMaps);
+	public Texture newTexture(Pixmap pixmap, PixmapFormat format);
 
 	public TextureRegion newTextureRegion(Texture texture);
 


### PR DESCRIPTION
MonoGame supports MipMaps only on contente processed using its content pipeline