### PR TITLE
Fix for #117, now the shape rendering draws directly to the spritebatch without using pixmaps

### DIFF
--- a/monogame/Graphics/MonoGameColor.cs
+++ b/monogame/Graphics/MonoGameColor.cs
@@ -294,6 +294,11 @@ namespace monogame.Graphics
             return (uint) (r << 24 | g << 16 | b << 8 | a);
         }
 
+        public static UInt32 toARGB8888(byte r, byte g, byte b, byte a)
+        {
+            return (uint) (a << 24 | r << 16 | g << 8 | b);
+        }
+
         public static UInt32 toRGBA8888(Microsoft.Xna.Framework.Color color)
         {
             return (uint) (color.R << 24 | color.G << 16 | color.B << 8 | color.A);
@@ -385,6 +390,11 @@ namespace monogame.Graphics
         public byte toIntensity()
         {
             return toIntensity(toRGBA8888());
+        }
+
+        public static uint toArgb(Color color)
+        {
+            return toARGB8888(color.getRAsByte(), color.getGAsByte(), color.getBAsByte(), color.getAAsByte());
         }
     }
 }

--- a/monogame/Graphics/MonoGameShapeRenderer.cs
+++ b/monogame/Graphics/MonoGameShapeRenderer.cs
@@ -1,0 +1,301 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using org.mini2Dx.core.geom;
+
+namespace monogame.Graphics
+{
+    public class MonoGameShapeRenderer
+    {
+        private GraphicsDevice _graphicsDevice;
+        private uint _color;
+        private Vector2 _rotationCenter, _translation, _scale;
+        private Color _tint;
+        private readonly SpriteBatch _spriteBatch;
+
+        public MonoGameShapeRenderer(GraphicsDevice graphicsDevice, uint colorARGB8888, SpriteBatch spriteBatch, Vector2 rotationCenter, Vector2 translation, Vector2 scale, Color tint)
+        {
+            _graphicsDevice = graphicsDevice;
+            _color = colorARGB8888;
+            _spriteBatch = spriteBatch;
+            _rotationCenter = rotationCenter;
+            _translation = translation;
+            _scale = scale;
+            _tint = tint;
+        }
+
+        public void setRotationCenter(Vector2 rotationCenter)
+        {
+            _rotationCenter = rotationCenter;
+        }
+
+        public void setTranslation(Vector2 translation)
+        {
+            _translation = translation;
+        }
+
+        public void setScale(Vector2 scale)
+        {
+            _scale = scale;
+        }
+
+        public void setTint(Color tint)
+        {
+            _tint = tint;
+        }
+
+        public void setColor(uint colorARGB8888)
+        {
+            _color = colorARGB8888;
+        }
+        
+        private void draw(Texture2D texture, Vector2 position)
+        {
+            _spriteBatch.Draw(texture,
+                (position + _translation - _rotationCenter) * _scale, null, _tint, 0f, 
+                Vector2.Zero, _scale, SpriteEffects.None, 0f);
+        }
+
+        private Texture2D newTexture2D(int width, int height)
+        {
+            return new Texture2D(_graphicsDevice, width, height, false, SurfaceFormat.Color);
+        }
+
+        public void drawLine(int x, int y, int x2, int y2)
+        {
+            var minX = Math.Min(x, x2);
+            var minY = Math.Min(y, y2);
+
+            x -= minX;
+            x2 -= minX;
+            y -= minY;
+            y2 -= minY;
+            
+            var deltaX = x2 - x;
+            var deltaY = y2 - y;
+            
+            var deltaXSign = Math.Sign(deltaX);
+            var deltaYSign = Math.Sign(deltaY);
+            
+            var dx2 = deltaXSign;
+            var dy2 = 0;
+            
+            var width = Math.Abs(deltaX);
+            var height = Math.Abs(deltaY);
+            
+            var texture = newTexture2D(width + 1, height + 1);
+            var textureData = new uint[texture.Width  * texture.Height];
+
+            if (width <= height)
+            {
+                width = Math.Abs(deltaY);
+                height = Math.Abs(deltaX);
+                dy2 = Math.Sign(deltaY);
+                dx2 = 0;
+            }
+            var numerator = width >> 1 ;
+            for (var i=0; i<=width; i++)
+            {
+                textureData[x + y * texture.Width] = _color;
+                numerator += height;
+                if (numerator >= width)
+                {
+                    numerator -= width;
+                    x += deltaXSign;
+                    y += deltaYSign;
+                } 
+                else
+                {
+                    x += dx2;
+                    y += dy2;
+                }
+            }
+            
+            texture.SetData(textureData);
+            draw(texture, new Vector2(minX, minY));
+        }
+
+        public void drawTriangle(int x1, int y1, int x2, int y2, int x3, int y3)
+        {
+            drawLine(x1, y1, x2, y2);
+            drawLine(x2, y2, x3, y3);
+            drawLine(x3, y3, x1, y1);
+        }
+
+        public void drawRect(int x, int y, int width, int height)
+        {
+            var texture = newTexture2D(width, height);
+            var textureData = new uint[width * height];
+            for (int i = 0; i < width; i++)
+            {
+                textureData[i] = _color;
+                textureData[textureData.Length - 1 - i] = _color;
+            }
+            for (int i = 1; i < height; i++)
+            {
+                textureData[width * i] = _color;
+                textureData[textureData.Length - 1 - width * i] = _color;
+            }
+            texture.SetData(textureData);
+            draw(texture, new Vector2(x, y));
+        }
+
+        public void fillRect(int x, int y, int width, int height)
+        {
+            var texture = newTexture2D(width, height);
+            var textureData = new uint[width * height];
+            
+            for (int i = 0; i < textureData.Length; i++)
+            {
+                textureData[i] = _color;
+            }
+            
+            texture.SetData(textureData);
+            draw(texture, new Vector2(x, y));
+        }
+        
+        private static void putPixel(uint[] pixels, int width, int height, int pixX, int pixY, uint color)
+        {
+            if (pixX >= 0 && pixX < width && pixY >= 0 && pixY < height)
+            {
+                pixels[pixX + width * pixY] = color;
+            }
+        }
+        
+        public void drawCircle(int centerX, int centerY, int radius)
+            {
+            var texture = newTexture2D(radius * 2 + 1, radius * 2 + 1);
+            var textureData = new uint[texture.Width * texture.Height];
+
+            var radiusSquared = radius * radius;
+            putPixel(textureData, texture.Width, texture.Height, radius, radius + radius, _color);
+            putPixel(textureData, texture.Width, texture.Height, radius, radius - radius, _color);
+            putPixel(textureData, texture.Width, texture.Height, radius + radius, radius, _color);
+            putPixel(textureData, texture.Width, texture.Height, radius - radius, radius, _color);
+            var x = 1;
+            var y = (int) Math.Sqrt(radiusSquared - 1);
+            while (x < y) {
+                putPixel(textureData, texture.Width, texture.Height, radius + x, radius + y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius + x, radius - y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - x, radius + y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - x, radius - y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius + y, radius + x, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius + y, radius - x, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - y, radius + x, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - y, radius - x, _color);
+                x += 1;
+                y = (int) (Math.Sqrt(radiusSquared - x*x));
+            }
+            if (x == y) {
+                putPixel(textureData, texture.Width, texture.Height, radius + x, radius + y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius + x, radius - y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - x, radius + y, _color);
+                putPixel(textureData, texture.Width, texture.Height, radius - x, radius - y, _color);
+            }
+
+            texture.SetData(textureData);
+            draw(texture, new Vector2(centerX - radius, centerY - radius));
+        }
+
+        public void fillCircle(int centerX, int centerY, int radius)
+        {
+            var texture = newTexture2D(radius * 2, radius * 2);
+            var textureData = new uint[texture.Width * texture.Height];
+            
+            for (int circleX = 0; circleX < radius * 2; circleX++)
+            {
+             
+                for (int circleY = 0; circleY < radius * 2; circleY++)
+                {
+                    if (Math.Pow(circleX - radius, 2) + Math.Pow(circleY - radius, 2) <= Math.Pow(radius, 2))
+                    {
+                        textureData[circleX + texture.Width * circleY] = _color;
+                    }
+                }
+            }
+
+            texture.SetData(textureData);
+            draw(texture, new Vector2(centerX - radius, centerY - radius));
+        }
+
+        public void fillTriangle(int x1, int y1, int x2, int y2, int x3, int y3)
+        {
+            var xMin = Math.Min(x1, Math.Min(x2, x3));
+            var yMin = Math.Min(y1, Math.Min(y2, y3));
+            var xMax = Math.Max(x1, Math.Max(x2, x3));
+            var yMax = Math.Max(y1, Math.Max(y2, y3));
+            var texture = newTexture2D(xMax - xMin, yMax - yMin);
+            var textureData = new uint[texture.Width * texture.Height];
+            
+            x1 -= xMin;
+            x2 -= xMin;
+            x3 -= xMin;
+            y1 -= yMin;
+            y2 -= yMin;
+            y3 -= yMin;
+            
+            //sort the vertices by y
+            if (y1 > y2)
+            {
+                //swap x1, x2
+                x1 ^= x2;
+                x2 ^= x1;
+                x1 ^= x2;
+                
+                //swap y1, y2
+                y1 ^= y2;
+                y2 ^= y1;
+                y1 ^= y2;
+            }
+            if (y1 > y3)
+            {
+                //swap x1, x3
+                x1 ^= x3;
+                x3 ^= x1;
+                x1 ^= x3;
+                
+                //swap y1, y3
+                y1 ^= y3;
+                y3 ^= y1;
+                y1 ^= y3;
+            }
+            if (y2 > y3)
+            {
+                //swap x2, x3
+                x2 ^= x3;
+                x3 ^= x2;
+                x2 ^= x3;
+                
+                //swap y2, y3
+                y2 ^= y3;
+                y3 ^= y2;
+                y2 ^= y3;
+            }
+
+            var triangleHeight = y3 - y1;
+            for (var i = 0; i < triangleHeight; i++)
+            {
+                var secondHalf = i > y2 - y1 || y2 == y1;
+                var segmentHeight = secondHalf ? y3 - y2 : y2 - y1;
+                var alpha = (float) i / triangleHeight;
+                var beta = (float) (i - (secondHalf ? y2 - y1 : 0)) / segmentHeight;
+                var aX = x1 + (x3 - x1) * alpha;
+                var bX = secondHalf ? x2 + (x3 - x2) * beta : x1 + (x2 - x1) * beta;
+                if (aX > bX)
+                {
+                    aX += bX;
+                    bX = aX - bX;
+                    aX -= bX;
+                }
+
+                for (var j = (int) aX; j <= bX; j++)
+                {
+                    textureData[j + texture.Width * (y1 + i)] = _color;
+                }
+            }
+            
+            texture.SetData(textureData);
+            draw(texture, new Vector2(xMin, yMin));
+        }
+    }
+}

--- a/monogame/mini2Dx-monogame.csproj
+++ b/monogame/mini2Dx-monogame.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Files\MonoGameFileHandle.cs" />
     <Compile Include="Graphics\MonoGameColor.cs" />
     <Compile Include="Graphics\MonoGamePixmap.cs" />
+    <Compile Include="Graphics\MonoGameShapeRenderer.cs" />
     <Compile Include="Graphics\MonoGameSprite.cs" />
     <Compile Include="Graphics\MonoGameTexture.cs" />
     <Compile Include="Graphics\MonoGameTextureRegion.cs" />

--- a/uats-monogame/Game1.cs
+++ b/uats-monogame/Game1.cs
@@ -40,7 +40,8 @@ namespace uats_monogame
         private Sprite sampleSprite;
         private Music music;
         private Sound sound;
-
+        private Vector2 mousePosition;
+        
         public Game1()
         {
             graphics = new GraphicsDeviceManager(this);
@@ -49,12 +50,20 @@ namespace uats_monogame
 
         private class UATInputProcessor : InputProcessor
         {
-            public static Music music;
-            public static Sound sound;
-            public static Vector2 mousePosition = Vector2.Zero;
+            private readonly Game1 game;
+
+            public UATInputProcessor(Game1 game)
+            {
+                this.game = game;
+            }
 
             public bool keyDown(int keycode)
             {
+                if (keycode == Input.Keys.ESCAPE)
+                {
+                    Console.WriteLine("Exiting...");
+                    game.Exit();
+                }
                 Console.WriteLine("keyDown({0})", keycode);
                 return false;
             }
@@ -77,25 +86,25 @@ namespace uats_monogame
                 {
                     case Input.Buttons.LEFT:
                     {
-                        if (music.isPlaying())
+                        if (game.music.isPlaying())
                         {
-                            music.pause();
+                            game.music.pause();
                         }
                         else
                         {
-                            music.play();
+                            game.music.play();
                         }
-                        Console.WriteLine("isPlaying: {0}", music.isPlaying());
+                        Console.WriteLine("isPlaying: {0}", game.music.isPlaying());
                         break;
                     }
 
                     case Input.Buttons.RIGHT:
-                        music.setLooping(!music.isLooping());
-                        Console.WriteLine("isLooping: {0}", music.isLooping());
+                        game.music.setLooping(!game.music.isLooping());
+                        Console.WriteLine("isLooping: {0}", game.music.isLooping());
                         break;
                     
                     case Input.Buttons.MIDDLE:
-                        sound.play();
+                        game.sound.play();
                         break;
                 }
 
@@ -117,8 +126,8 @@ namespace uats_monogame
 
             public bool mouseMoved(int screenX, int screenY)
             {
-                mousePosition.X = screenX;
-                mousePosition.Y = screenY;
+                game.mousePosition.X = screenX;
+                game.mousePosition.Y = screenY;
                 Console.WriteLine("mouseMoved({0}, {1})", screenX, screenY);
                 return false;
             }
@@ -153,7 +162,7 @@ namespace uats_monogame
         {
             Mdx.input = new MonoGameInput();
             Mdx.files = new MonoGameFiles(Content);
-            Mdx.input.setInputProcessor(new UATInputProcessor());
+            Mdx.input.setInputProcessor(new UATInputProcessor(this));
             base.Initialize();
         }
 
@@ -176,10 +185,7 @@ namespace uats_monogame
             Mdx.graphicsContext.setBackgroundColor(new MonoGameColor(Color.Blue));
             sampleSprite.setOriginCenter();
             music = Mdx.audio.newMusic(Mdx.files.@internal("music.ogg"));
-            UATInputProcessor.music = music;
-
             sound = Mdx.audio.newSound(Mdx.files.@internal("sound.wav"));
-            UATInputProcessor.sound = sound;
             
             Mdx.audio.addMusicCompletionListener(new AudioCompletionListener());
             Mdx.audio.addSoundCompletionListener(new AudioCompletionListener());
@@ -200,9 +206,6 @@ namespace uats_monogame
         /// <param name="gameTime">Provides a snapshot of timing values.</param>
         protected override void Update(GameTime gameTime)
         {
-            if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-                Exit();
-
             ((MonoGameInput)Mdx.input).update();
             ((MonoGameAudio)Mdx.audio).update();
             base.Update(gameTime);
@@ -233,9 +236,8 @@ namespace uats_monogame
             sampleSprite.setOriginBasedPosition(windowWidth / 2f, windowHeight / 2f);
             Mdx.graphicsContext.drawSprite(sampleSprite);
             Mdx.graphicsContext.setColor(new MonoGameColor(Color.Green));
-            Mdx.graphicsContext.fillTriangle(UATInputProcessor.mousePosition.X, UATInputProcessor.mousePosition.Y,
-                UATInputProcessor.mousePosition.X + 10, UATInputProcessor.mousePosition.Y + 20,
-                UATInputProcessor.mousePosition.X, UATInputProcessor.mousePosition.Y + 20);
+            Mdx.graphicsContext.fillTriangle(mousePosition.X, mousePosition.Y, mousePosition.X + 10,
+                mousePosition.Y + 20, mousePosition.X, mousePosition.Y + 20);
             
             Mdx.graphicsContext.postRender();
             Console.WriteLine("FPS: {0}", 1.0/gameTime.ElapsedGameTime.TotalSeconds);


### PR DESCRIPTION
Below there are 3 squashed commit messages:

1. Added MonoGameColor.toArgb(Color)
2. Implemented a shape rendered that draws a shape to the spritebatch without using pixmaps
3. Now MonoGameGraphics uses the new shape renderer