### PR TITLE
Implemented FrameBuffer API

### DIFF
--- a/core/src/main/java/org/mini2Dx/core/graphics/FrameBuffer.java
+++ b/core/src/main/java/org/mini2Dx/core/graphics/FrameBuffer.java
@@ -52,4 +52,10 @@ public interface FrameBuffer extends Disposable {
 	 * @return The height in pixels
 	 */
 	public int getHeight();
+
+	/**
+	 * Returns the texture containing this frame buffer's data.
+	 * @return The texture containing this frame buffer's data.
+	 */
+	public Texture getTexture();
 }

--- a/monogame/Graphics/MonoGameFrameBuffer.cs
+++ b/monogame/Graphics/MonoGameFrameBuffer.cs
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright 2019 Viridian Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+using Microsoft.Xna.Framework.Graphics;
+using org.mini2Dx.core;
+using Texture = org.mini2Dx.core.graphics.Texture;
+
+namespace monogame.Graphics
+{
+    public class MonoGameFrameBuffer : org.mini2Dx.core.graphics.FrameBuffer
+    {
+        private GraphicsDevice _graphicsDevice;
+        private RenderTarget2D _renderTarget;
+        private MonoGameTexture texture;
+
+        public MonoGameFrameBuffer(GraphicsDevice graphicsDevice, int width, int height)
+        {
+            _graphicsDevice = graphicsDevice;
+            _renderTarget = new RenderTarget2D(graphicsDevice, width, height, false, SurfaceFormat.Color, DepthFormat.Depth24);
+            texture = new MonoGameTexture(null);
+        }
+        
+        public void dispose()
+        {
+            _renderTarget.Dispose();
+        }
+
+        public void begin()
+        {
+            ((MonoGameGraphics)Mdx.graphicsContext).endSpriteBatch();
+            bind();
+            ((MonoGameGraphics)Mdx.graphicsContext).clearGraphicsDevice(((MonoGameGraphics)Mdx.graphicsContext)._backgroundColor);
+            ((MonoGameGraphics)Mdx.graphicsContext)._gameWidth = _renderTarget.Width;
+            ((MonoGameGraphics)Mdx.graphicsContext)._gameHeight = _renderTarget.Height;
+            ((MonoGameGraphics)Mdx.graphicsContext).beginSpriteBatch();
+        }
+
+        public void end()
+        {
+            ((MonoGameGraphics)Mdx.graphicsContext).endSpriteBatch();
+            unbind();
+            ((MonoGameGraphics)Mdx.graphicsContext)._gameWidth = Mdx.graphicsContext.getWindowWidth();
+            ((MonoGameGraphics)Mdx.graphicsContext)._gameHeight = Mdx.graphicsContext.getWindowHeight();
+            ((MonoGameGraphics)Mdx.graphicsContext).beginSpriteBatch();
+        }
+
+        public void bind()
+        {
+            _graphicsDevice.SetRenderTarget(_renderTarget);
+        }
+
+        public void unbind()
+        {
+            _graphicsDevice.SetRenderTarget(null);
+        }
+
+        public int getWidth()
+        {
+            return _renderTarget.Width;
+        }
+
+        public int getHeight()
+        {
+            return _renderTarget.Height;
+        }
+
+        public Texture getTexture()
+        {
+            texture.texture2D = _renderTarget;
+            return texture;
+        }
+    }
+}

--- a/monogame/Graphics/MonoGameTexture.cs
+++ b/monogame/Graphics/MonoGameTexture.cs
@@ -22,7 +22,7 @@ namespace monogame.Graphics
 {
     class MonoGameTexture : org.mini2Dx.core.graphics.Texture
     {
-        public readonly Texture2D texture2D;
+        internal Texture2D texture2D;
 
         public MonoGameTexture(Texture2D texture2D)
         {

--- a/monogame/Graphics/MonoGameTextureRegion.cs
+++ b/monogame/Graphics/MonoGameTextureRegion.cs
@@ -295,17 +295,14 @@ namespace monogame.Graphics
                 boundingRect.Y -= _regionHeight;
             }
             
-            var rawSrcTextureData = new uint[_regionWidth * _regionHeight]; //4 because in RGBA8888 each pixel is 4 bytes
-            var rawSrcTextureColor = new Color[_regionWidth * _regionHeight]; //4 because in RGBA8888 each pixel is 4 bytes
+            var rawSrcTextureData = new uint[_regionWidth * _regionHeight];
             srcTexture.GetData(0, boundingRect, rawSrcTextureData, 0, rawSrcTextureData.Length);
-            srcTexture.GetData(0, boundingRect, rawSrcTextureColor, 0, rawSrcTextureData.Length);
 
             if (srcTexture.Format == SurfaceFormat.ColorSRgb)
             {
                 for (int i = 0; i < rawSrcTextureData.Length; i++)
                 {
-                    var alpha = rawSrcTextureData[i] & 0xff;
-                    rawSrcTextureData[i] = (rawSrcTextureData[i] >> 8) | (alpha << 24);
+                    rawSrcTextureData[i] = MonoGameColor.rgbaToArgb(rawSrcTextureData[i]);
                 }
             }
 

--- a/monogame/MonoGameGraphics.cs
+++ b/monogame/MonoGameGraphics.cs
@@ -14,12 +14,10 @@
  * limitations under the License.
  ******************************************************************************/
 
-using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using monogame.Graphics;
 using monogame.Util;
-using org.mini2Dx.core;
 using org.mini2Dx.core.font;
 using org.mini2Dx.core.geom;
 using org.mini2Dx.core.graphics;
@@ -35,12 +33,11 @@ namespace monogame
     {
         private readonly SpriteBatch _spriteBatch;
         private readonly GraphicsDevice _graphicsDevice;
-        private readonly GraphicsUtils _graphicsUtils;
         private Color _setColor = new MonoGameColor(255,255,255,255);
-        private Microsoft.Xna.Framework.Color _backgroundColor = Microsoft.Xna.Framework.Color.Black;
+        internal Microsoft.Xna.Framework.Color _backgroundColor = Microsoft.Xna.Framework.Color.Black;
         private Microsoft.Xna.Framework.Color _tint = Microsoft.Xna.Framework.Color.White;
         private float _rotation;
-        private int _gameWidth, _gameHeight;
+        internal int _gameWidth, _gameHeight;
 
         private MonoGameShapeRenderer _shapeRenderer;
         
@@ -59,23 +56,38 @@ namespace monogame
         {
             _spriteBatch = new SpriteBatch(graphicsDevice);
             _graphicsDevice = graphicsDevice;
-            _graphicsUtils = new MonoGameGraphicsUtils(graphicsDevice);
             _translation = Vector2.Zero;
             _scale = Vector2.One;
             _rotationCenter = Vector2.Zero;
             _shapeRenderer = new MonoGameShapeRenderer(graphicsDevice, MonoGameColor.toArgb(_setColor), _spriteBatch, _rotationCenter, _translation, _scale, _tint);
         }
+
+        internal void beginSpriteBatch()
+        {
+            _spriteBatch.Begin(SpriteSortMode.FrontToBack, _blendState, transformMatrix: Matrix.CreateRotationZ(MonoGameMathsUtil.degreeToRadian(_rotation)) * Matrix.CreateTranslation(new Vector3((_rotationCenter + _translation) * _scale, 0)));
+        }
+
+        internal void endSpriteBatch()
+        {
+            _spriteBatch.End();
+        }
+
+        internal void clearGraphicsDevice(Microsoft.Xna.Framework.Color color)
+        {
+            _graphicsDevice.Clear(color);
+        }
+        
         
         public void preRender(int gameWidth, int gameHeight)
         {
             if (!_isFlushing)
             {
-                _graphicsDevice.Clear(_backgroundColor);
+                clearGraphicsDevice(_backgroundColor);
             }
 
             _gameWidth = gameWidth;
             _gameHeight = gameHeight;
-            _spriteBatch.Begin(SpriteSortMode.FrontToBack, _blendState, transformMatrix: Matrix.CreateRotationZ(MonoGameMathsUtil.degreeToRadian(_rotation)) * Matrix.CreateTranslation(new Vector3((_rotationCenter + _translation) * _scale, 0)));
+            beginSpriteBatch();
         }
 
         public void postRender()
@@ -421,47 +433,47 @@ namespace monogame
 
         public bool isWindowReady()
         {
-            return getWindowHeight() != 0;
+            return _gameHeight != 0;
         }
 
         public int getWindowWidth()
         {
-            return _gameWidth;
+            return _graphicsDevice.PresentationParameters.BackBufferWidth;
         }
 
         public int getWindowHeight()
         {
-            return _gameHeight;
+            return _graphicsDevice.PresentationParameters.BackBufferHeight;
         }
         
         public int getWindowSafeX()
         {
-            throw new System.NotImplementedException();
+            return _graphicsDevice.Viewport.TitleSafeArea.X;
         }
 
         public int getWindowSafeY()
         {
-            throw new System.NotImplementedException();
+            return _graphicsDevice.Viewport.TitleSafeArea.Y;
         }
 
         public int getWindowSafeWidth()
         {
-            throw new System.NotImplementedException();
+            return _graphicsDevice.Viewport.TitleSafeArea.Width;
         }
 
         public int getWindowSafeHeight()
         {
-            throw new System.NotImplementedException();
+            return _graphicsDevice.Viewport.TitleSafeArea.Height;
         }
 
         public float getViewportWidth()
         {
-            throw new System.NotImplementedException();
+            return _gameWidth;
         }
 
         public float getViewportHeight()
         {
-            throw new System.NotImplementedException();
+            return _gameHeight;
         }
 
         public Matrix4 getProjectionMatrix()

--- a/monogame/mini2Dx-monogame.csproj
+++ b/monogame/mini2Dx-monogame.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Audio\MonoGameSound.cs" />
     <Compile Include="Files\MonoGameFileHandle.cs" />
     <Compile Include="Graphics\MonoGameColor.cs" />
+    <Compile Include="Graphics\MonoGameFrameBuffer.cs" />
     <Compile Include="Graphics\MonoGamePixmap.cs" />
     <Compile Include="Graphics\MonoGameShapeRenderer.cs" />
     <Compile Include="Graphics\MonoGameSprite.cs" />

--- a/uats-monogame/Game1.cs
+++ b/uats-monogame/Game1.cs
@@ -216,12 +216,12 @@ namespace uats_monogame
         /// <param name="gameTime">Provides a snapshot of timing values.</param>
         protected override void Draw(GameTime gameTime)
         {
-            Mdx.graphicsContext.preRender(GraphicsDevice.Viewport.Bounds.Width, GraphicsDevice.Viewport.Bounds.Height);
+            Mdx.graphicsContext.preRender(Mdx.graphicsContext.getWindowWidth(), Mdx.graphicsContext.getWindowHeight());
             Mdx.graphicsContext.setColor(new MonoGameColor(Color.White));
             
-            var windowWidth = Mdx.graphicsContext.getWindowWidth();
-            var windowHeight = Mdx.graphicsContext.getWindowHeight();
-            Mdx.graphicsContext.drawRect(windowWidth/8f, windowHeight/8f, 3 * windowWidth/4f, 3 * windowHeight/4f);
+            var gameWidth = Mdx.graphicsContext.getViewportWidth();
+            var gameHeight = Mdx.graphicsContext.getViewportHeight();
+            Mdx.graphicsContext.drawRect(gameWidth/8f, gameHeight/8f, 3 * gameWidth/4f, 3 * gameHeight/4f);
             Mdx.graphicsContext.fillRect(400, 300, 32, 32);
             Mdx.graphicsContext.drawCircle(200, 200, 40);
             Mdx.graphicsContext.fillCircle(300, 300, 20);
@@ -232,7 +232,7 @@ namespace uats_monogame
             Mdx.graphicsContext.drawTexture(sampleTexture, 200, 100);
             Mdx.graphicsContext.drawTextureRegion(sampleRegion, 500, 300);
             Mdx.graphicsContext.drawTextureRegion(sampleRegion2, 600, 150, 100, 100);
-            sampleSprite.setOriginBasedPosition(windowWidth / 2f, windowHeight / 2f);
+            sampleSprite.setOriginBasedPosition(gameWidth / 2f, gameHeight / 2f);
             Mdx.graphicsContext.drawSprite(sampleSprite);
             Mdx.graphicsContext.setColor(new MonoGameColor(Color.Green));
             Mdx.graphicsContext.fillTriangle(mousePosition.X, mousePosition.Y, mousePosition.X + 10,


### PR DESCRIPTION
Below there are 7 squashed commit messages:

1. Added FrameBuffer.getTexture()
2. Changed MonoGameTexture.texture2D access modifier to internal and made it writable
3. Added to MonoGameGraphics some methods useful for the FrameBuffer API
4. Implemented some more MonoGameGraphics methods
5. Implemented the FrameBuffer API
6. Removed some useless debug instructions from MonoGameTextureRegion.
7. Now the UAT uses the correct methods to get the game size