### PR TITLE
Fixed shaders

### DIFF
--- a/monogame/Graphics/MonoGameShader.cs
+++ b/monogame/Graphics/MonoGameShader.cs
@@ -28,6 +28,11 @@ namespace monogame.Graphics
         {
             shader = ((MonoGameFiles) Mdx.files)._contentManager.Load<Effect>(name);
         }
+
+        public MonoGameShader(Effect effect)
+        {
+            shader = effect;
+        }
         
         public void dispose()
         {

--- a/uats-monogame/Game1.cs
+++ b/uats-monogame/Game1.cs
@@ -337,7 +337,10 @@ namespace uats_monogame
             Mdx.graphicsContext.drawTriangle(150, 74, 122, 108, 214, 147);
             Mdx.graphicsContext.drawTexture(sampleTexture, 200, 100);
             Mdx.graphicsContext.drawTextureRegion(sampleRegion, 500, 300);
+            var prevShader = Mdx.graphicsContext.getShader();
+            Mdx.graphicsContext.setShader(sampleShader);
             Mdx.graphicsContext.drawTextureRegion(sampleAtlasRegion, 400, 200);
+            Mdx.graphicsContext.setShader(prevShader);
             Mdx.graphicsContext.drawTextureRegion(sampleRegion2, 600, 150, 100, 100);
             sampleSprite.setOriginBasedPosition(gameWidth / 2, gameHeight / 2);
             Mdx.graphicsContext.drawSprite(sampleSprite);


### PR DESCRIPTION
Now you can correctly apply a shader only to some objects without
applying it to the whole viewport
Implemented missing setClip method
FIxed MonoGameGraphics.flush() method