### PR TITLE
UI Listener Adapters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@
 - Added new GamePad API with improved controller/feature support (third-party controllers, rumble, player index, etc.)
 - Simplified geometry class hierarchy
 
+[1.9.8]
+- Added ActionListenerAdapter, HoverListenerAdapter, and UiInputSourceListenerAdapter
+
 [1.9.7]
 - Added overridable onMouseMoved, onMouseDown, onMouseUp events to CustomUiElement
 

--- a/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
@@ -1,0 +1,15 @@
+package org.mini2Dx.ui.listener;
+
+import org.mini2Dx.ui.event.ActionEvent;
+
+/**
+ * Adapter class that implements {@link ActionListener}. All methods are
+ * no-op and can be overridden individually.
+ */
+public class ActionListenerAdapater implements ActionListener {
+    @Override
+    public void onActionBegin(ActionEvent event) {}
+
+    @Override
+    public void onActionEnd(ActionEvent event) {}
+}

--- a/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2019 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 package org.mini2Dx.ui.listener;
 
 import org.mini2Dx.ui.event.ActionEvent;

--- a/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/ActionListenerAdapater.java
@@ -5,6 +5,8 @@ import org.mini2Dx.ui.event.ActionEvent;
 /**
  * Adapter class that implements {@link ActionListener}. All methods are
  * no-op and can be overridden individually.
+ *
+ * @author Caidan Williams
  */
 public class ActionListenerAdapater implements ActionListener {
     @Override

--- a/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
@@ -5,6 +5,8 @@ import org.mini2Dx.ui.element.Hoverable;
 /**
  * Adapter class that implements {@link HoverListener}. All methods are
  * no-op and can be overridden individually.
+ *
+ * @author Caidan Williams
  */
 public class HoverListenerAdapter implements HoverListener {
     @Override

--- a/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
@@ -1,0 +1,15 @@
+package org.mini2Dx.ui.listener;
+
+import org.mini2Dx.ui.element.Hoverable;
+
+/**
+ * Adapter class that implements {@link HoverListener}. All methods are
+ * no-op and can be overridden individually.
+ */
+public class HoverListenerAdapter implements HoverListener {
+    @Override
+    public void onHoverBegin(Hoverable source) {}
+
+    @Override
+    public void onHoverEnd(Hoverable source) {}
+}

--- a/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/HoverListenerAdapter.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2019 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 package org.mini2Dx.ui.listener;
 
 import org.mini2Dx.ui.element.Hoverable;

--- a/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2019 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 package org.mini2Dx.ui.listener;
 
 import org.mini2Dx.core.input.GamePadType;

--- a/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
@@ -1,0 +1,17 @@
+package org.mini2Dx.ui.listener;
+
+import org.mini2Dx.core.input.GamePadType;
+import org.mini2Dx.ui.InputSource;
+import org.mini2Dx.ui.UiContainer;
+
+/**
+ * Adapter class that implements {@link UiInputSourceListener}. All methods are
+ * no-op and can be overridden individually.
+ */
+public class UiInputSourceListenerAdapter implements UiInputSourceListener {
+    @Override
+    public void inputSourceChanged(UiContainer container, InputSource oldInputSource, InputSource newInputSource) {}
+
+    @Override
+    public void gamePadTypeChanged(UiContainer container, GamePadType oldGamePadType, GamePadType newGamePadType) {}
+}

--- a/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
+++ b/ui/src/main/java/org/mini2Dx/ui/listener/UiInputSourceListenerAdapter.java
@@ -7,6 +7,8 @@ import org.mini2Dx.ui.UiContainer;
 /**
  * Adapter class that implements {@link UiInputSourceListener}. All methods are
  * no-op and can be overridden individually.
+ *
+ * @author Caidan Williams
  */
 public class UiInputSourceListenerAdapter implements UiInputSourceListener {
     @Override


### PR DESCRIPTION
New Classes
---
- ActionListenerAdapater
- HoverListenerAdapter
- UiInputSourceListenerAdapater

Intentions
---
- Provides empty methods for interface implementations to reduce useless code when creating a new listener.
- Did not provide adapters for single method interfaces, as adapting those will provide no real value outside of being confusing for new developers.