### PR TITLE
better support for xml namespace prefixes

### DIFF
--- a/ui/src/main/java/org/mini2Dx/ui/xml/UiXmlLoader.java
+++ b/ui/src/main/java/org/mini2Dx/ui/xml/UiXmlLoader.java
@@ -117,9 +117,10 @@ public class UiXmlLoader {
     }
 
     private UiElement processXmlTag(XmlReader.Element root) {
-        UiElementHandler handler = tagNameToHandler.get(root.getName());
+        String tagName = XmlTagUtil.getTagNameWithoutPrefix(root);
+        UiElementHandler handler = tagNameToHandler.get(tagName);
         if (handler == null) {
-            throw new UnknownUiTagException(root.getName());
+            throw new UnknownUiTagException(tagName);
         }
 
         boolean childTagsAlreadyProcessed = false;

--- a/ui/src/main/java/org/mini2Dx/ui/xml/XmlTagUtil.java
+++ b/ui/src/main/java/org/mini2Dx/ui/xml/XmlTagUtil.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.mini2Dx.ui.xml;
+
+import org.mini2Dx.gdx.xml.XmlReader;
+
+public class XmlTagUtil {
+    public static String getTagNameWithoutPrefix(XmlReader.Element element) {
+        return element.getName().replaceAll("(.*?:)?(.+?)", "$2");
+    }
+}

--- a/ui/src/main/java/org/mini2Dx/ui/xml/spi/AbstractInvalidValueException.java
+++ b/ui/src/main/java/org/mini2Dx/ui/xml/spi/AbstractInvalidValueException.java
@@ -21,6 +21,8 @@ import org.mini2Dx.gdx.xml.XmlReader;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static org.mini2Dx.ui.xml.XmlTagUtil.getTagNameWithoutPrefix;
+
 public class AbstractInvalidValueException extends MdxException {
     public AbstractInvalidValueException(XmlReader.Element tag, String invalidValue, Object[] availableValues) {
         super(buildMessage(tag, invalidValue, availableValues));
@@ -34,8 +36,8 @@ public class AbstractInvalidValueException extends MdxException {
                 .collect(Collectors.joining("\n"));
 
         String prefix = tag.hasAttribute("id") ?
-                tag.getName() + " with id (" + tag.getAttribute("id") + ")"
-                : tag.getName();
+                getTagNameWithoutPrefix(tag) + " with id (" + tag.getAttribute("id") + ")"
+                : getTagNameWithoutPrefix(tag);
 
         StringBuilder builder = new StringBuilder()
                 .append(prefix)

--- a/ui/src/main/java/org/mini2Dx/ui/xml/spi/ImageButtonPopulator.java
+++ b/ui/src/main/java/org/mini2Dx/ui/xml/spi/ImageButtonPopulator.java
@@ -20,6 +20,8 @@ import org.mini2Dx.ui.element.Image;
 import org.mini2Dx.ui.element.ImageButton;
 import org.mini2Dx.ui.xml.UiElementPopulator;
 
+import static org.mini2Dx.ui.xml.XmlTagUtil.getTagNameWithoutPrefix;
+
 public class ImageButtonPopulator implements UiElementPopulator<ImageButton> {
     @Override
     public boolean populate(XmlReader.Element xmlTag, ImageButton uiElement) {
@@ -42,7 +44,7 @@ public class ImageButtonPopulator implements UiElementPopulator<ImageButton> {
     private Image determineImage(ImageButton uiElement, XmlReader.Element child) {
         Image image;
 
-        switch (child.getName()) {
+        switch (getTagNameWithoutPrefix(child)) {
             case "normal-texture":
                 image = uiElement.getNormalImage();
                 break;

--- a/ui/src/test/java/org/mini2Dx/ui/xml/AbstractParentUiElementXmlTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/AbstractParentUiElementXmlTest.java
@@ -25,6 +25,18 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractParentUiElementXmlTest<T extends ParentUiElement> extends AbstractUiElementXmlTest<T> {
 
     @Test
+    public void supports_all_components_as_child_tags_with_namespace_prefix() {
+        String xml = newBuilder()
+                .withNamespacePrefix("ui")
+                .withAllComponentTagsAsChildren()
+                .build();
+
+        System.out.println(xml);
+
+        assertXmlIsValid(xml);
+    }
+
+    @Test
     public void supports_all_components_as_child_tags() {
         String xml = newBuilder()
                 .withAllComponentTagsAsChildren()

--- a/ui/src/test/java/org/mini2Dx/ui/xml/AnimatedImageTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/AnimatedImageTest.java
@@ -24,6 +24,18 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AnimatedImageTest extends AbstractUiElementXmlTest<AnimatedImage> {
+    @Test
+    public void with_namespace_prefix() {
+        String xml = "<?xml version=\"1.0\"?>" +
+                "<ui:animated-image xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\">" +
+                "   <ui:texture duration=\"100\">blah</ui:texture>" +
+                "   <ui:texture duration=\"100\">blah</ui:texture>" +
+                "</ui:animated-image>";
+
+        AnimatedImage element = loadFile(xml);
+
+        assertEquals(2, element.getFrameDurations().length);
+    }
 
     @Test
     public void with_atlas() {

--- a/ui/src/test/java/org/mini2Dx/ui/xml/ImageButtonTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/ImageButtonTest.java
@@ -29,6 +29,22 @@ import static org.junit.Assert.assertTrue;
 public class ImageButtonTest extends AbstractUiElementXmlTest<ImageButton> {
 
     @Test
+    public void with_tag_prefix() {
+        String xml = "<?xml version=\"1.0\"?>" +
+                "<ui:container xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\">" +
+                "    <ui:image-button id=\"test\">" +
+                "       <ui:normal-texture>blah</ui:normal-texture>" +
+                "       <ui:hover-texture>blah</ui:hover-texture>" +
+                "       <ui:action-texture>blah</ui:action-texture>" +
+                "       <ui:disabled-texture>blah</ui:disabled-texture>" +
+                "   </ui:image-button>" +
+                "</ui:container>";
+
+
+        loadFile(xml);
+    }
+
+    @Test
     public void with_disabled_texture_flipped_y() {
         ImageButton element = loadFile("" +
                 "<image-button responsive=\"true\">" +

--- a/ui/src/test/java/org/mini2Dx/ui/xml/RadioButtonTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/RadioButtonTest.java
@@ -26,6 +26,20 @@ import static org.junit.Assert.assertTrue;
 public class RadioButtonTest extends AbstractUiElementXmlTest<RadioButton> {
 
     @Test
+    public void with_namespace_prefix() {
+        String xml =
+                "<ui:radio-button id=\"blah\" xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\">" +
+                        "  <ui:option>0</ui:option>" +
+                        "  <ui:option>1</ui:option>" +
+                        "  <ui:option>2</ui:option>" +
+                        "</ui:radio-button>";
+
+        RadioButton element = loadFile(xml);
+
+        assertEquals(3, element.getTotalOptions());
+    }
+
+    @Test
     public void responsive_provided() {
         RadioButton element = loadFile("<radio-button id=\"x\" responsive=\"true\" />");
 

--- a/ui/src/test/java/org/mini2Dx/ui/xml/SelectTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/SelectTest.java
@@ -26,6 +26,20 @@ import static org.junit.Assert.assertTrue;
 
 public class SelectTest extends AbstractUiElementXmlTest<Select<String>> {
     @Test
+    public void with_namespace_prefix() {
+        String xml = "<?xml version=\"1.0\"?>" +
+                "<ui:select xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\">" +
+                "   <ui:option value=\"0\">text-0</ui:option>" +
+                "   <ui:option value=\"1\">text-1</ui:option>" +
+                "   <ui:option value=\"2\">text-2</ui:option>" +
+                "</ui:select>";
+
+        Select element = loadFile(xml);
+
+        assertEquals(3, element.getTotalOptions());
+    }
+
+    @Test
     public void right_button_text_is_provided() {
         String xml = "<select right-button-text=\"blah\" />";
 

--- a/ui/src/test/java/org/mini2Dx/ui/xml/TabViewTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/TabViewTest.java
@@ -24,6 +24,22 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TabViewTest extends AbstractUiElementXmlTest<TabView> {
+    @Test
+    public void with_namespace_prefix() {
+        String xml =
+                "<ui:tab-view xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\" >" +
+                        " <ui:tab title=\"1\">" +
+                        "   <ui:container/>" +
+                        " </ui:tab>" +
+                        " <ui:tab title=\"2\">" +
+                        "   <ui:container/>" +
+                        " </ui:tab>" +
+                        "</ui:tab-view>";
+
+        TabView element = loadFile(xml);
+
+        assertEquals(2, element.getTotalTabs());
+    }
 
     @Test
     public void with_layout() {

--- a/ui/src/test/java/org/mini2Dx/ui/xml/TestXmlUiBuilder.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/TestXmlUiBuilder.java
@@ -22,10 +22,10 @@ import java.util.function.Supplier;
 import static org.junit.Assert.assertNotNull;
 
 public class TestXmlUiBuilder {
-    private static final String NAMESPACE = " xmlns=\"https://github.com/mini2Dx/mini2Dx\"";
     private final String tagName;
     private ObjectMap<String, String> attributes = new ObjectMap<>();
     private Supplier<String> childTagSupplier = () -> "";
+    private String prefix;
 
     public TestXmlUiBuilder(String tagName) {
         this.tagName = tagName;
@@ -44,44 +44,56 @@ public class TestXmlUiBuilder {
 
     public TestXmlUiBuilder withAllComponentTagsAsChildren() {
         return withChildTagSupplier(() -> {
-            return "    <text-button id=\"x\" text=\"hello\"/>" +
-                    "    <label text=\"blah\"/>" +
-                    "    <text-box id=\"x\"/>" +
-                    "    <container/>" +
-                    "    <flex-row/>" +
-                    "    <div/>" +
-                    "    <check-box id=\"x\"/>" +
-                    "    <progress-bar id=\"x\"/>" +
-                    "    <radio-button id=\"x\">" +
-                    "      <option>1</option>" +
-                    "      <option>2</option>" +
-                    "    </radio-button>" +
-                    "    <slider id=\"x\"/>" +
-                    "    <select id=\"x\">" +
-                    "      <option>1</option>" +
-                    "      <option>2</option>" +
-                    "    </select>" +
-                    "    <image texture-path=\"x\"/>" +
-                    "    <scroll-box />" +
-                    "    <animated-image>" +
-                    "      <texture duration=\"1\">foo</texture>" +
-                    "      <texture duration=\"2\">bar</texture>" +
-                    "    </animated-image>" +
-                    "    <image-button id=\"1\">" +
-                    "      <normal-texture>blah</normal-texture>" +
-                    "    </image-button>" +
-                    "    <tab-view>" +
-                    "    </tab-view>" +
-                    "    <button id=\"x\" />";
+            return "    <" + getTagPrefix() + "text-button id=\"x\" text=\"hello\"/>" +
+                    "    <" + getTagPrefix() + "label text=\"blah\"/>" +
+                    "    <" + getTagPrefix() + "text-box id=\"x\"/>" +
+                    "    <" + getTagPrefix() + "container/>" +
+                    "    <" + getTagPrefix() + "flex-row/>" +
+                    "    <" + getTagPrefix() + "div/>" +
+                    "    <" + getTagPrefix() + "check-box id=\"x\"/>" +
+                    "    <" + getTagPrefix() + "progress-bar id=\"x\"/>" +
+                    "    <" + getTagPrefix() + "radio-button id=\"x\">" +
+                    "      <" + getTagPrefix() + "option>1</" + getTagPrefix() + "option>" +
+                    "      <" + getTagPrefix() + "option>2</" + getTagPrefix() + "option>" +
+                    "    </" + getTagPrefix() + "radio-button>" +
+                    "    <" + getTagPrefix() + "slider id=\"x\"/>" +
+                    "    <" + getTagPrefix() + "select id=\"x\">" +
+                    "      <" + getTagPrefix() + "option>1</" + getTagPrefix() + "option>" +
+                    "      <" + getTagPrefix() + "option>2</" + getTagPrefix() + "option>" +
+                    "    </" + getTagPrefix() + "select>" +
+                    "    <" + getTagPrefix() + "image texture-path=\"x\"/>" +
+                    "    <" + getTagPrefix() + "scroll-box />" +
+                    "    <" + getTagPrefix() + "animated-image>" +
+                    "      <" + getTagPrefix() + "texture duration=\"1\">foo</" + getTagPrefix() + "texture>" +
+                    "      <" + getTagPrefix() + "texture duration=\"2\">bar</" + getTagPrefix() + "texture>" +
+                    "    </" + getTagPrefix() + "animated-image>" +
+                    "    <" + getTagPrefix() + "image-button id=\"1\">" +
+                    "      <" + getTagPrefix() + "normal-texture>blah</" + getTagPrefix() + "normal-texture>" +
+                    "    </" + getTagPrefix() + "image-button>" +
+                    "    <" + getTagPrefix() + "tab-view>" +
+                    "    </" + getTagPrefix() + "tab-view>" +
+                    "    <" + getTagPrefix() + "button id=\"x\" />";
 
         });
+    }
+
+    public TestXmlUiBuilder withNamespacePrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
     }
 
     public String build() {
         StringBuilder builder = new StringBuilder();
         builder.append("<")
+                .append(getTagPrefix())
                 .append(tagName)
-                .append(NAMESPACE);
+                .append(" xmlns");
+
+        if (applyPrefix()) {
+            builder.append(":").append(prefix);
+        }
+
+        builder.append("=\"https://github.com/mini2Dx/mini2Dx\"");
 
         for (ObjectMap.Entry<String, String> entry : attributes) {
             builder.append(" ")
@@ -94,7 +106,15 @@ public class TestXmlUiBuilder {
         builder.append(">");
 
         builder.append(childTagSupplier.get());
-        builder.append("</").append(tagName).append(">");
+        builder.append("</").append(getTagPrefix()).append(tagName).append(">");
         return builder.toString();
+    }
+
+    private String getTagPrefix() {
+        return applyPrefix() ? prefix + ":" : "";
+    }
+
+    private boolean applyPrefix() {
+        return prefix != null && prefix.trim().length() > 0;
     }
 }

--- a/ui/src/test/java/org/mini2Dx/ui/xml/UiXmlLoaderTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/UiXmlLoaderTest.java
@@ -45,13 +45,23 @@ public class UiXmlLoaderTest extends AbstractUiXmlLoaderTest {
     }
 
     @Test
+    public void namespace_can_be_aliased() {
+        String xml =
+                "<ui:container xmlns:ui=\"https://github.com/mini2Dx/mini2Dx\">" +
+                        "</ui:container>";
+
+        Container container = loadFile(xml);
+        assertNotNull(container);
+    }
+
+    @Test
     public void nested_containers() {
         String xml =
                 "<container id=\"1\">" +
-                "  <container id=\"2\">" +
-                "    <container id=\"3\"/>" +
-                "  </container>" +
-                "</container>";
+                        "  <container id=\"2\">" +
+                        "    <container id=\"3\"/>" +
+                        "  </container>" +
+                        "</container>";
 
         Container container = loadFile(xml);
         assertEquals("1", container.getId());

--- a/ui/src/test/java/org/mini2Dx/ui/xml/XmlTagUtilTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/XmlTagUtilTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.mini2Dx.ui.xml;
+
+import org.junit.Test;
+import org.mini2Dx.gdx.xml.XmlReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.mini2Dx.ui.xml.XmlTagUtil.getTagNameWithoutPrefix;
+
+public class XmlTagUtilTest {
+    @Test
+    public void with_prefix() {
+        XmlReader.Element element = new XmlReader.Element("ui:text", null);
+        assertEquals("text", getTagNameWithoutPrefix(element));
+    }
+
+    @Test
+    public void no_prefix() {
+        XmlReader.Element element = new XmlReader.Element("text", null);
+        assertEquals("text", getTagNameWithoutPrefix(element));
+    }
+}


### PR DESCRIPTION
Currently, if someone uses a prefix on the XML namespace (eg. <ui:container>) this would force them to redefine all the tag handling on the UiXmlLoader, which would not be desired. So instead we strip off the namespace prefix so we only deal with the real tag name so a user can name the prefix whatever they with and the UiXmlLoader should function as expected.