### PR TITLE
fix travis ci  android build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ notifications:
     on_success: change
     on_failure: always
 before_script:
+  - curl 1https://gist.githubusercontent.com/peanutbother/ea3c119f4d219439f03e4505fb161726/raw/d98694346c3a08cdba93109649a9f71b3c334938/android-sdk-license.sh | sh
   - yes | sdkmanager --update
 script: ./gradlew  clean build --stacktrace -x :mini2Dx-uats-libgdx-android:check -x :mini2Dx-uats-libgdx-android:validateSigningDebug -x :mini2Dx-uats-libgdx-android:packageDebug


### PR DESCRIPTION
taken from https://github.com/jitpack/jitpack.io/issues/3687#issuecomment-455901608
this script (which should get copied to your gist!) accepts all required licenses for the targeted android sdk

please create a fork gist on mini2dx or an account of a trusted contributor and change gist url with new url

```sh
#!/bin/bash

<< ////
The script creates 'licenses' under '$ANDROID_HOME' and creates a file which proves 
that the SDK license was accepted by the user.

Please copy this to your own account/gist/server. Every time there's an updated license, update the file with the new 
license hash.
Legally if you run this script (or your own version of it), it means YOU accepted the license - don't trust someone else.
The hashes below are supposed to be taken from $ANDROID_HOME/licenses/android-sdk-license on YOUR machine, after you 
accepted the license yourself.
See here for more info: https://developer.android.com/studio/intro/update#download-with-gradle

Usage:
In .travis.yml
before_script:
  - curl URL_OF_THIS_FILE | sh
  
In jitpack.yml
before_install:
  - curl URL_OF_THIS_FILE | sh
////

set -ex

cd $ANDROID_HOME
mkdir -p licenses

cat << EOF >> licenses/android-sdk-license
8933bad161af4178b1185d1a37fbf41ea5269c55
d56f5187479451eabf01fb78af6dfcb131a6481e
24333f8a63b6825ea9c5514f83c2829b004d1fee
EOF
```