### PR TITLE
Update UiXmlLoader

### DIFF
--- a/ui/src/test/java/org/mini2Dx/ui/xml/AbstractUiXmlLoaderTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/AbstractUiXmlLoaderTest.java
@@ -80,6 +80,27 @@ public abstract class AbstractUiXmlLoaderTest {
         return loader.load(filename, model);
     }
 
+
+    protected <T> T loadFileWithModel(String xml, T model) {
+        final String realXml = "<?xml version=\"1.0\"?>\n" + xml;
+
+        FileHandle fileHandle = mockery.mock(FileHandle.class);
+
+        mockery.checking(new Expectations() {
+            {
+                oneOf(fileHandleResolver).resolve(filename);
+                will(returnValue(fileHandle));
+                try {
+                    oneOf(fileHandle).reader();
+                    will(returnValue(new StringReader(realXml)));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        return loader.load(filename, model);
+    }
+
     protected <T extends UiElement> T loadFile(String xml) {
         final String realXml = "<?xml version=\"1.0\"?>\n" + xml;
 

--- a/ui/src/test/java/org/mini2Dx/ui/xml/UiXmlLoaderTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/UiXmlLoaderTest.java
@@ -141,4 +141,27 @@ public class UiXmlLoaderTest extends AbstractUiXmlLoaderTest {
             assertEquals("container or model is null", e.getCause().getMessage());
         }
     }
+
+    @Test
+    public void load_with_model_instance() {
+        String xml = "<container id=\"testContainer\" visibility=\"HIDDEN\" />";
+        UiModel model = loadFileWithModel(xml, new UiModel());
+
+        assertNotNull(model.testContainer);
+        assertNotNull(model.testContainerCustom);
+        assertEquals(model.testContainer.getVisibility(), Visibility.HIDDEN);
+        assertEquals(model.testContainerCustom.getVisibility(), Visibility.HIDDEN);
+    }
+
+    @Test
+    public void fail_to_load_with_model_instance_null() {
+        String xml = "<container id=\"testContainer\" visibility=\"HIDDEN\" />";
+
+        try {
+            loadFileWithModel(xml, null);
+        } catch (MdxException e) {
+            assertEquals("Failed to populate Ui file " + filename, e.getMessage());
+            assertEquals("container or model is null", e.getCause().getMessage());
+        }
+    }
 }


### PR DESCRIPTION
added overload to populate existing model-instance

+ `<T> T load(String filename, T model)`
+ `<T extends UiElement, M> M populateModel(T container, M model)`

Unit Tests:
+ `void load_with_model_instance()`
+ `void fail_to_load_with_model_instance_null()`

Unit Test Abstraction:
+ `<T> T loadFileWithModel(String xml, T model)`