### PR TITLE
Issue #59 - graphics texture

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@
 - Simplified geometry class hierarchy
 - Optimised shape rendering under LibGDX
 - Fixed UI input when rendering to a viewport
+- Added support for rendering textures with a shape applied
 
 [1.9.10]
 - Update to latest RoboVM to support iOS 12

--- a/core/src/main/java/org/mini2Dx/core/Graphics.java
+++ b/core/src/main/java/org/mini2Dx/core/Graphics.java
@@ -261,6 +261,16 @@ public interface Graphics {
      *
      * @param texture
      *            The {@link Texture} to draw
+     * @param shape
+     *            The {@link Shape} applied to the provided {@link Texture}
+     */
+    public void drawTexture(Texture texture, Shape shape);
+
+    /**
+     * Draws a texture to this graphics context
+     *
+     * @param texture
+     *            The {@link Texture} to draw
      * @param x
      *            The x coordinate to draw at
      * @param y

--- a/libgdx/src/main/java/org/mini2Dx/libgdx/LibgdxGraphics.java
+++ b/libgdx/src/main/java/org/mini2Dx/libgdx/LibgdxGraphics.java
@@ -437,6 +437,11 @@ public class LibgdxGraphics implements Graphics {
 	}
 
 	@Override
+	public void drawTexture(Texture texture, Shape shape) {
+		drawTexture(texture, shape.getX(), shape.getY(), shape.getWidth(), shape.getHeight());
+	}
+
+	@Override
 	public void drawTexture(Texture texture, float x, float y) {
 		drawTexture(texture, x, y, texture.getWidth(), texture.getHeight());
 	}


### PR DESCRIPTION
Noticed that issue #59 was tagged with help wanted so I jumped in to help. Here is a brief description of what I changed and some additional questions that I have.

### What Changed
- Added another overloaded Graphics.drawTexture method that applies the x, y, width, and height values of a provided shape to the texture being drawn.
- Updated the CHANGES file with details regarding this additional functionality

### Questions
- Code-related
  - Should the shape's rotation also be applied to the texture somehow?
  - How should I go about writing unit tests for this?
- General
  - Which branch should I point this PR to?
  - Does this change require cutting a maven central release?

Thanks for your time, hopefully this is helpful. 😄 