### PR TITLE
Implemented character limit for TextBox UI element.

### DIFF
--- a/ui/src/main/java/org/mini2Dx/ui/element/TextBox.java
+++ b/ui/src/main/java/org/mini2Dx/ui/element/TextBox.java
@@ -58,6 +58,8 @@ public class TextBox extends UiElement implements Actionable, FlexUiElement {
 	private boolean enabled = true;
 	@Field(optional = true)
 	private boolean passwordField = false;
+	@Field(optional = true)
+	private int characterLimit = -1;
 	
 	protected TextBoxRenderNode renderNode;
 
@@ -197,6 +199,9 @@ public class TextBox extends UiElement implements Actionable, FlexUiElement {
 		if (value.equals(this.value)) {
 			return;
 		}
+		if (characterLimit >= 0 && value.length() > characterLimit) {
+			return;
+		}
 		this.value = value;
 		
 		if (renderNode == null) {
@@ -219,6 +224,29 @@ public class TextBox extends UiElement implements Actionable, FlexUiElement {
 	 */
 	public void setPasswordField(boolean passwordField) {
 		this.passwordField = passwordField;
+	}
+
+	/**
+	 * Returns the current character limit of this {@link TextBox}.
+	 * @return a negative integer if there is no character limit or positive number (including zero) if such limit is
+	 * set.
+	 */
+	public int getCharacterLimit() {
+		return characterLimit;
+	}
+
+	/**
+	 * Sets the character limit for this {@link TextBox}. Any negative number will disable the character limit.
+	 * Any positive number (including zero) will trigger this behavior. If this {@link TextBox} reaches the
+	 * character limit it will stop accepting any newer input.
+	 * @param characterLimit
+	 */
+	public void setCharacterLimit(int characterLimit) {
+		this.characterLimit = characterLimit;
+	}
+
+	public boolean isCharacterLimitReached() {
+		return characterLimit >= 0 && value.length() >= characterLimit;
 	}
 
 	@Override

--- a/ui/src/main/java/org/mini2Dx/ui/xml/spi/TextBoxPopulator.java
+++ b/ui/src/main/java/org/mini2Dx/ui/xml/spi/TextBoxPopulator.java
@@ -25,6 +25,7 @@ public class TextBoxPopulator implements UiElementPopulator<TextBox> {
         uiElement.setValue(xmlTag.getAttribute("value", null));
         uiElement.setEnabled(xmlTag.getBoolean("enabled", true));
         uiElement.setPasswordField(xmlTag.getBoolean("password", false));
+        uiElement.setCharacterLimit(xmlTag.getInt("characterLimit", -1));
         uiElement.setFlexLayout(xmlTag.getAttribute("layout", "flex-column:xs-12c"));
         return false;
     }

--- a/ui/src/main/resources/mini2dx-ui.xsd
+++ b/ui/src/main/resources/mini2dx-ui.xsd
@@ -317,6 +317,7 @@
                     <xsd:attribute name="id" type="xsd:string" use="required"/>
                     <xsd:attribute name="value" type="xsd:string"/>
                     <xsd:attribute name="password" type="xsd:boolean" default="false"/>
+                    <xsd:attribute name="characterLimit" type="xsd:integer" default="-1"/>
                     <xsd:attribute name="enabled" type="xsd:boolean" default="true"/>
                     <xsd:attribute name="layout" type="xsd:string" default="flex-column:xs-12c"/>
                 </xsd:extension>

--- a/ui/src/test/java/org/mini2Dx/ui/element/TextBoxTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/element/TextBoxTest.java
@@ -1,0 +1,45 @@
+package org.mini2Dx.ui.element;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TextBoxTest {
+
+    @Test
+    public void testTextBoxWithZeroAsCharacterLimit() {
+        TextBox textBox = new TextBox();
+        textBox.setCharacterLimit(0);
+        simulateUserInput(textBox);
+
+        assertEquals(textBox.getValue(), "");
+        assertTrue(textBox.isCharacterLimitReached());
+    }
+
+    @Test
+    public void testTextBoxWithCharacterLimit() {
+        TextBox textBox = new TextBox();
+        textBox.setCharacterLimit(3);
+        simulateUserInput(textBox);
+
+        assertEquals(textBox.getValue(), "012");
+        assertTrue(textBox.isCharacterLimitReached());
+    }
+
+    @Test
+    public void testTextBoxWithoutCharacterLimit() {
+        TextBox textBox = new TextBox();
+        simulateUserInput(textBox);
+
+        assertEquals(textBox.getValue(), "01234");
+        assertFalse(textBox.isCharacterLimitReached());
+    }
+
+    private void simulateUserInput(TextBox textBox) {
+        String valueToAdd = "";
+        for(int i = 0; i < 5; i++) {
+            valueToAdd += Integer.toString(i);
+            textBox.setValue(valueToAdd);
+        }
+    }
+}

--- a/ui/src/test/java/org/mini2Dx/ui/xml/TextBoxTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/xml/TextBoxTest.java
@@ -32,6 +32,13 @@ public class TextBoxTest extends AbstractUiElementXmlTest<TextBox> {
     }
 
     @Test
+    public void text_box_character_limit_field_provided() {
+        TextBox element = loadFile("<text-box id=\"x\" characterLimit=\"3\" />");
+
+        assertEquals(element.getCharacterLimit(), 3);
+    }
+
+    @Test
     public void text_box_enabled_provided() {
         TextBox element = loadFile("<text-box id=\"x\" enabled=\"false\" />");
 
@@ -75,6 +82,7 @@ public class TextBoxTest extends AbstractUiElementXmlTest<TextBox> {
                 "              height=\"1\"" +
                 "              visibility=\"HIDDEN\"" +
                 "              password=\"true\"" +
+                "              characterLimit=\"10\"" +
                 "              value=\"hello\"" +
                 "              enabled=\"false\"" +
                 "              layout=\"blah\"" +


### PR DESCRIPTION
Added an optional character limit feature to TextBox. By default, the character limit is -1 (disabled). Any negative number will disable the limit. Any positive number (zero included) will enable the limit. Once the limit has been reached, the TextBox will no longer accept inputs. Callers can verify if they reached the limit with the `isCharacterLimitReached` method.

Closes #268