### PR TITLE
Implement method to get collisions ignoring edge overlap.

### DIFF
--- a/core/src/main/java/org/mini2Dx/core/collision/ConcurrentPointQuadTree.java
+++ b/core/src/main/java/org/mini2Dx/core/collision/ConcurrentPointQuadTree.java
@@ -630,6 +630,65 @@ public class ConcurrentPointQuadTree<T extends Positionable> extends Rectangle i
 	}
 
 	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area);
+		return result;
+	}
+
+	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area, QuadTreeSearchDirection searchDirection) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area, searchDirection);
+		return result;
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area) {
+		lock.lockRead();
+		if (topLeft != null) {
+			topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			topRight.getElementsWithinAreaIgnoringEdges(result, area);
+			bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+		} else {
+			addElementsWithinArea(result, area);
+		}
+		lock.unlockRead();
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area, QuadTreeSearchDirection searchDirection) {
+		switch (searchDirection){
+			case UPWARDS:
+				lock.lockRead();
+				if (elements != null) {
+					addElementsWithinArea(result, area);
+				}
+				if (parent != null) {
+					if (parent.topLeft != this && (area.contains(parent.topLeft) || area.intersectsIgnoringEdges(parent.topLeft))) {
+						parent.topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.topRight != this && (area.contains(parent.topRight) || area.intersectsIgnoringEdges(parent.topRight))) {
+						parent.topRight.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.bottomLeft != this && (area.contains(parent.bottomLeft) || area.intersectsIgnoringEdges(parent.bottomLeft))) {
+						parent.bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.bottomRight != this && (area.contains(parent.bottomRight) || area.intersectsIgnoringEdges(parent.bottomRight))) {
+						parent.bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					parent.getElementsWithinAreaIgnoringEdges(result, area, searchDirection);
+				}
+				lock.unlockRead();
+				break;
+			case DOWNWARDS:
+				getElementsWithinAreaIgnoringEdges(result, area);
+				break;
+		}
+	}
+
+	@Override
 	public Array<T> getElementsContainingArea(Shape area, boolean entirelyContained) {
 		return new Array<>();
 	}

--- a/core/src/main/java/org/mini2Dx/core/collision/PointQuadTree.java
+++ b/core/src/main/java/org/mini2Dx/core/collision/PointQuadTree.java
@@ -505,6 +505,61 @@ public class PointQuadTree<T extends Positionable> extends Rectangle implements 
 	}
 
 	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area);
+		return result;
+	}
+
+	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area, QuadTreeSearchDirection searchDirection) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area, searchDirection);
+		return result;
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area) {
+		if (topLeft != null) {
+			topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			topRight.getElementsWithinAreaIgnoringEdges(result, area);
+			bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+		} else {
+			addElementsWithinArea(result, area);
+		}
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area, QuadTreeSearchDirection searchDirection) {
+		switch (searchDirection){
+			case UPWARDS:
+				if (elements != null) {
+					addElementsWithinArea(result, area);
+				}
+				if (parent != null) {
+					if (parent.topLeft != this && (area.contains(parent.topLeft) || area.intersectsIgnoringEdges(parent.topLeft))) {
+						parent.topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.topRight != this && (area.contains(parent.topRight) || area.intersectsIgnoringEdges(parent.topRight))) {
+						parent.topRight.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.bottomLeft != this && (area.contains(parent.bottomLeft) || area.intersectsIgnoringEdges(parent.bottomLeft))) {
+						parent.bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					if (parent.bottomRight != this && (area.contains(parent.bottomRight) || area.intersectsIgnoringEdges(parent.bottomRight))) {
+						parent.bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+					}
+					parent.getElementsWithinAreaIgnoringEdges(result, area, searchDirection);
+				}
+				break;
+			case DOWNWARDS:
+				getElementsWithinAreaIgnoringEdges(result, area);
+				break;
+		}
+	}
+
+	@Override
 	public Array<T> getElementsContainingArea(Shape area, boolean entirelyContained) {
 		return new Array<>();
 	}

--- a/core/src/main/java/org/mini2Dx/core/collision/QuadTree.java
+++ b/core/src/main/java/org/mini2Dx/core/collision/QuadTree.java
@@ -64,6 +64,14 @@ public interface QuadTree<T extends Positionable> extends PositionChangeListener
 
 	public void getElementsWithinArea(Array<T> result, Shape area, QuadTreeSearchDirection searchDirection);
 
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area);
+
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area, QuadTreeSearchDirection searchDirection);
+
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area);
+
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area, QuadTreeSearchDirection searchDirection);
+
 	public Array<T> getElementsContainingArea(Shape area, boolean entirelyContained);
 
 	public Array<T> getElementsContainingArea(Shape area, QuadTreeSearchDirection searchDirection, boolean entirelyContained);

--- a/core/src/main/java/org/mini2Dx/core/collision/RegionQuadTree.java
+++ b/core/src/main/java/org/mini2Dx/core/collision/RegionQuadTree.java
@@ -290,6 +290,15 @@ public class RegionQuadTree<T extends Sizeable> extends PointQuadTree<T> {
 		}
 	}
 
+	protected void addElementsWithinAreaIgnoringEdges(Array<T> result, Shape area) {
+		for (int i = elements.size - 1; i >= 0; i--) {
+			T element = elements.get(i);
+			if (element != null && (area.contains(element) || area.intersectsIgnoringEdges(element))) {
+				result.add(element);
+			}
+		}
+	}
+
 	@Override
 	public void getElementsWithinArea(Array<T> result, Shape area) {
 		if (topLeft != null) {
@@ -349,6 +358,82 @@ public class RegionQuadTree<T extends Sizeable> extends PointQuadTree<T> {
 				parent.bottomRight.getElementsWithinArea(result, area);
 			}
 			((RegionQuadTree<T>)parent).getElementsWithinAreaUpwards(result, area, false);
+		}
+	}
+
+	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area);
+		return result;
+	}
+
+	@Override
+	public Array<T> getElementsWithinAreaIgnoringEdges(Shape area, QuadTreeSearchDirection searchDirection) {
+		Array<T> result = new Array<T>();
+		getElementsWithinAreaIgnoringEdges(result, area, searchDirection);
+		return result;
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area) {
+		if (topLeft != null) {
+			if (topLeft.contains(area) || topLeft.intersectsIgnoringEdges(area))
+				topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			if (topRight.contains(area) || topRight.intersectsIgnoringEdges(area))
+				topRight.getElementsWithinAreaIgnoringEdges(result, area);
+			if (bottomLeft.contains(area) || bottomLeft.intersectsIgnoringEdges(area))
+				bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			if (bottomRight.contains(area) || bottomRight.intersectsIgnoringEdges(area))
+				bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+		}
+		addElementsWithinAreaIgnoringEdges(result, area);
+	}
+
+	@Override
+	public void getElementsWithinAreaIgnoringEdges(Array<T> result, Shape area, QuadTreeSearchDirection searchDirection) {
+		switch (searchDirection){
+			case UPWARDS:
+				getElementsWithinAreaIgnoringEdgesUpwards(result, area, true);
+				break;
+			case DOWNWARDS:
+				this.getElementsWithinAreaIgnoringEdges(result, area);
+				break;
+		}
+	}
+
+	private void getElementsWithinAreaIgnoringEdgesUpwards(Array<T> result, Shape area, boolean firstInvocation) {
+		if (elements != null) {
+			addElementsWithinArea(result, area);
+		}
+		if (firstInvocation && topLeft != null){
+			if (area.contains(topLeft) || area.intersectsIgnoringEdges(topLeft)){
+				topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (area.contains(topRight) || area.intersectsIgnoringEdges(topRight)){
+				topRight.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (area.contains(bottomLeft) || area.intersectsIgnoringEdges(bottomLeft)){
+				bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (area.contains(bottomRight) || area.intersectsIgnoringEdges(bottomRight)){
+				bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+		}
+		if (parent != null) {
+			if (parent.topLeft != this && (area.contains(parent.topLeft) || area.intersectsIgnoringEdges(parent.topLeft))) {
+				parent.topLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (parent.topRight != this && (area.contains(parent.topRight) || area.intersectsIgnoringEdges(parent.topRight))) {
+				parent.topRight.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (parent.bottomLeft != this && (area.contains(parent.bottomLeft) || area.intersectsIgnoringEdges(parent.bottomLeft))) {
+				parent.bottomLeft.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			if (parent.bottomRight != this && (area.contains(parent.bottomRight) || area.intersectsIgnoringEdges(parent.bottomRight))) {
+				parent.bottomRight.getElementsWithinAreaIgnoringEdges(result, area);
+			}
+			((RegionQuadTree<T>)parent).getElementsWithinAreaIgnoringEdgesUpwards(result, area, false);
 		}
 	}
 

--- a/core/src/main/java/org/mini2Dx/core/geom/Circle.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Circle.java
@@ -212,7 +212,15 @@ public class Circle extends Shape {
 		}
 		return shape.getPolygon().intersects(this);
 	}
-	
+
+	@Override
+	public boolean intersectsIgnoringEdges(Sizeable shape) {
+		if(shape.isCircle()) {
+			return intersectsIgnoringEdges((Circle) shape);
+		}
+		return shape.getPolygon().intersectsIgnoringEdges(this);
+	}
+
 	@Override
 	public boolean intersectsLineSegment(Vector2 pointA, Vector2 pointB) {
 		final Vector2 centerTmp = CENTER_TMP.get();
@@ -259,6 +267,10 @@ public class Circle extends Shape {
 	 */
 	public boolean intersects(Circle circle) {
 		return Vector2.dst(this.circle.x, this.circle.y, circle.getX(), circle.getY()) <= this.circle.radius + circle.getRadius();
+	}
+
+	public boolean intersectsIgnoringEdges(Circle circle) {
+		return Vector2.dst(this.circle.x, this.circle.y, circle.getX(), circle.getY()) < this.circle.radius + circle.getRadius();
 	}
 	
 	/**

--- a/core/src/main/java/org/mini2Dx/core/geom/Rectangle.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Rectangle.java
@@ -172,6 +172,11 @@ public class Rectangle extends Shape {
 		return polygon.intersects(shape);
 	}
 
+	@Override
+	public boolean intersectsIgnoringEdges(Sizeable shape) {
+		return polygon.intersectsIgnoringEdges(shape);
+	}
+
 	/**
 	 * Returns if the specified {@link Circle} intersects this {@link Rectangle}
 	 * 

--- a/core/src/main/java/org/mini2Dx/core/geom/RegularPolygon.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/RegularPolygon.java
@@ -157,6 +157,11 @@ public class RegularPolygon extends Shape {
 	}
 
 	@Override
+	public boolean intersectsIgnoringEdges(Sizeable shape) {
+		return polygon.intersectsIgnoringEdges(shape);
+	}
+
+	@Override
 	public boolean intersects(LineSegment lineSegment) {
 		return intersectsLineSegment(lineSegment.getPointA(), lineSegment.getPointB());
 	}

--- a/core/src/main/java/org/mini2Dx/core/geom/Sizeable.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Sizeable.java
@@ -57,6 +57,13 @@ public interface Sizeable extends Positionable {
 	public boolean intersects(Sizeable shape);
 
 	/**
+	 * Returns if this shape intersects a shape. False if only the edges overlap.
+	 * @param shape The {@link Sizeable} to check
+	 * @return True if this shape intersects the specified {@link Sizeable}
+	 */
+	public boolean intersectsIgnoringEdges(Sizeable shape);
+
+	/**
 	 * Returns if this shape intersects the specified
 	 * {@link LineSegment}
 	 *

--- a/core/src/main/java/org/mini2Dx/core/geom/Triangle.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Triangle.java
@@ -133,7 +133,12 @@ public class Triangle extends Shape {
 	public boolean intersects(Sizeable shape) {
 		return polygon.intersects(shape);
 	}
-	
+
+	@Override
+	public boolean intersectsIgnoringEdges(Sizeable shape) {
+		return polygon.intersectsIgnoringEdges(shape);
+	}
+
 	@Override
 	public boolean intersects(LineSegment lineSegment) {
 		return intersectsLineSegment(lineSegment.getPointA(), lineSegment.getPointB());

--- a/core/src/test/java/org/mini2Dx/core/collision/ConcurrentPointQuadTreeTest.java
+++ b/core/src/test/java/org/mini2Dx/core/collision/ConcurrentPointQuadTreeTest.java
@@ -257,6 +257,41 @@ public class ConcurrentPointQuadTreeTest implements Runnable {
 	}
 
 	@Test
+	public void testGetElementsWithinRegionIgnoringEdges() {
+		rootQuad.add(point1);
+		rootQuad.add(point2);
+		rootQuad.add(point3);
+		rootQuad.add(point4);
+
+		Array<CollisionPoint> collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point1, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(64, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point2, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point3, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(64, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point4, collisionPoints.get(0));
+
+		CollisionPoint collisionPoint5 = new CollisionPoint(32, 32);
+		CollisionPoint collisionPoint6 = new CollisionPoint(48, 48);
+		rootQuad.add(collisionPoint5);
+		rootQuad.add(collisionPoint6);
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64));
+		Assert.assertEquals(3, collisionPoints.size);
+		Assert.assertEquals(true, collisionPoints.contains(point1, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint5, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint6, false));
+	}
+
+	@Test
 	public void testGetElementsWithinRegionUpwards() {
 		rootQuad.add(qAPoint1);
 		rootQuad.add(qAPoint2);

--- a/core/src/test/java/org/mini2Dx/core/collision/PointQuadTreeTest.java
+++ b/core/src/test/java/org/mini2Dx/core/collision/PointQuadTreeTest.java
@@ -217,6 +217,41 @@ public class PointQuadTreeTest {
 	}
 
 	@Test
+	public void testGetElementsWithinRegionIgnoringEdges() {
+		rootQuad.add(point1);
+		rootQuad.add(point2);
+		rootQuad.add(point3);
+		rootQuad.add(point4);
+
+		Array<CollisionPoint> collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point1, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(64, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point2, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point3, collisionPoints.get(0));
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(64, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(point4, collisionPoints.get(0));
+
+		CollisionPoint collisionPoint5 = new CollisionPoint(32, 32);
+		CollisionPoint collisionPoint6 = new CollisionPoint(48, 48);
+		rootQuad.add(collisionPoint5);
+		rootQuad.add(collisionPoint6);
+
+		collisionPoints = rootQuad.getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64));
+		Assert.assertEquals(3, collisionPoints.size);
+		Assert.assertEquals(true, collisionPoints.contains(point1, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint5, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint6, false));
+	}
+
+	@Test
 	public void testGetElementsWithinRegionUpwards() {
 		rootQuad.add(qAPoint1);
 		rootQuad.add(qAPoint2);
@@ -247,6 +282,43 @@ public class PointQuadTreeTest {
 		rootQuad.add(collisionPoint6);
 
 		collisionPoints = qAPoint1.getQuad().getElementsWithinArea(new Rectangle(0, 0, 64, 64), QuadTreeSearchDirection.UPWARDS);
+		Assert.assertEquals(3, collisionPoints.size);
+		Assert.assertEquals(true, collisionPoints.contains(qAPoint1, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint5, false));
+		Assert.assertEquals(true, collisionPoints.contains(collisionPoint6, false));
+	}
+
+	@Test
+	public void testGetElementsWithinRegionIgnoringEdgesUpwards() {
+		rootQuad.add(qAPoint1);
+		rootQuad.add(qAPoint2);
+		rootQuad.add(qAPoint3);
+		rootQuad.add(qAPoint4);
+
+		Array<CollisionPoint> collisionPoints;
+
+		collisionPoints = qAPoint1.getQuad().getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(qAPoint1, collisionPoints.get(0));
+
+		collisionPoints = qAPoint2.getQuad().getElementsWithinAreaIgnoringEdges(new Rectangle(64, 0, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(qAPoint2, collisionPoints.get(0));
+
+		collisionPoints = qAPoint3.getQuad().getElementsWithinAreaIgnoringEdges(new Rectangle(0, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(qAPoint3, collisionPoints.get(0));
+
+		collisionPoints = qAPoint4.getQuad().getElementsWithinAreaIgnoringEdges(new Rectangle(64, 64, 64, 64));
+		Assert.assertEquals(1, collisionPoints.size);
+		Assert.assertEquals(qAPoint4, collisionPoints.get(0));
+
+		QuadTreeAwareCollisionPoint collisionPoint5 = new QuadTreeAwareCollisionPoint(32, 32);
+		QuadTreeAwareCollisionPoint collisionPoint6 = new QuadTreeAwareCollisionPoint(48, 48);
+		rootQuad.add(collisionPoint5);
+		rootQuad.add(collisionPoint6);
+
+		collisionPoints = qAPoint1.getQuad().getElementsWithinAreaIgnoringEdges(new Rectangle(0, 0, 64, 64), QuadTreeSearchDirection.UPWARDS);
 		Assert.assertEquals(3, collisionPoints.size);
 		Assert.assertEquals(true, collisionPoints.contains(qAPoint1, false));
 		Assert.assertEquals(true, collisionPoints.contains(collisionPoint5, false));

--- a/core/src/test/java/org/mini2Dx/core/collision/RegionQuadTreeTest.java
+++ b/core/src/test/java/org/mini2Dx/core/collision/RegionQuadTreeTest.java
@@ -245,6 +245,30 @@ public class RegionQuadTreeTest {
 	}
 
 	@Test
+	public void testGetElementsWithinR10egionIgnoringEdges() {
+		rootQuad.add(box1);
+		rootQuad.add(box2);
+		rootQuad.add(box3);
+		rootQuad.add(box4);
+
+		Array<CollisionBox> collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(48, 48, 32, 32));
+		Assert.assertEquals(0, collisionBoxs.size);
+
+		collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(0, 0, 128, 128));
+		Assert.assertEquals(rootQuad.getElements().size, collisionBoxs.size);
+
+		collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(32, 32, 8, 8));
+		Assert.assertEquals(1, collisionBoxs.size);
+		Assert.assertEquals(box1, collisionBoxs.get(0));
+
+		collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(33, 0, 8, 8));
+		Assert.assertEquals(0, collisionBoxs.size);
+
+		collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(0, 33, 8, 8));
+		Assert.assertEquals(0, collisionBoxs.size);
+	}
+
+	@Test
 	public void testGetElementsWithinRegionUpwards() {
 		rootQuad.add(qABox1);
 		rootQuad.add(qABox2);
@@ -285,6 +309,48 @@ public class RegionQuadTreeTest {
 		Assert.assertEquals(2, collisionBoxs.size);
 		Assert.assertEquals(true, collisionBoxs.contains(collisionBox6, false));
 		Assert.assertEquals(true, collisionBoxs.contains(collisionBox7, false));
+	}
+
+	@Test
+	public void testGetElementsWithinRegionIgnoringEdgesUpwards() {
+		rootQuad.add(qABox1);
+		rootQuad.add(qABox2);
+		rootQuad.add(qABox3);
+		rootQuad.add(qABox4);
+
+		Array<CollisionBox> collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(48, 48, 32, 32));
+		Assert.assertEquals(0, collisionBoxs.size);
+
+		QuadTreeAwareCollisionBox collisionBox5 = new QuadTreeAwareCollisionBox(24, 24, 2, 2);
+		QuadTreeAwareCollisionBox collisionBox6 = new QuadTreeAwareCollisionBox(48, 48, 32, 32);
+		QuadTreeAwareCollisionBox collisionBox7 = new QuadTreeAwareCollisionBox(12, 48, 8, 8);
+
+		rootQuad.add(collisionBox5);
+		rootQuad.add(collisionBox6);
+		rootQuad.add(collisionBox7);
+
+		collisionBoxs = rootQuad.getElementsWithinAreaIgnoringEdges(new CollisionBox(0, 0, 128, 128));
+		Assert.assertEquals(rootQuad.getElements().size, collisionBoxs.size);
+
+		collisionBoxs = collisionBox6.getQuad().getElementsWithinAreaIgnoringEdges(new CollisionBox(36, 36, 32, 32));
+		Assert.assertEquals(1, collisionBoxs.size);
+		Assert.assertEquals(collisionBox6, collisionBoxs.get(0));
+
+		collisionBoxs = qABox1.getQuad().getElementsWithinAreaIgnoringEdges(new CollisionBox(0, 0, 64, 64), QuadTreeSearchDirection.UPWARDS);
+		Assert.assertEquals(4, collisionBoxs.size);
+		Assert.assertEquals(true, collisionBoxs.contains(qABox1, false));
+		Assert.assertEquals(true, collisionBoxs.contains(collisionBox5, false));
+		Assert.assertEquals(true, collisionBoxs.contains(collisionBox6, false));
+		Assert.assertEquals(true, collisionBoxs.contains(collisionBox7, false));
+
+		collisionBoxs = qABox1.getQuad().getElementsWithinAreaIgnoringEdges(new CollisionBox(16, 16, 24, 24), QuadTreeSearchDirection.UPWARDS);
+		Assert.assertEquals(2, collisionBoxs.size);
+		Assert.assertEquals(true, collisionBoxs.contains(qABox1, false));
+		Assert.assertEquals(true, collisionBoxs.contains(collisionBox5, false));
+
+		collisionBoxs = qABox1.getQuad().getElementsWithinAreaIgnoringEdges(new CollisionBox(12, 40, 48, 8), QuadTreeSearchDirection.UPWARDS);
+		Assert.assertEquals(1, collisionBoxs.size);
+		Assert.assertEquals(true, collisionBoxs.contains(collisionBox6, false));
 	}
 	
 	@Test

--- a/core/src/test/java/org/mini2Dx/core/geom/CircleTest.java
+++ b/core/src/test/java/org/mini2Dx/core/geom/CircleTest.java
@@ -61,6 +61,17 @@ public class CircleTest {
 	}
 
 	@Test
+	public void testIntersectsIgnoringEdgesCircle() {
+		Circle circle2 = new Circle(20f, 20f, 4);
+		Assert.assertEquals(false, circle1.intersectsIgnoringEdges(circle2));
+		Assert.assertEquals(false, circle2.intersectsIgnoringEdges(circle1));
+
+		circle2.setXY(8f, 0f);
+		Assert.assertEquals(false, circle1.intersectsIgnoringEdges(circle2));
+		Assert.assertEquals(false, circle2.intersectsIgnoringEdges(circle1));
+	}
+
+	@Test
 	public void testGetDistanceToPositionable() {
 		Point point = new Point(3f, 0f);
 		Assert.assertEquals(0f, circle1.getDistanceTo(point), 0.00001f);

--- a/core/src/test/java/org/mini2Dx/core/geom/PolygonTest.java
+++ b/core/src/test/java/org/mini2Dx/core/geom/PolygonTest.java
@@ -636,10 +636,12 @@ public class PolygonTest {
 				new Point(-10f, 5f),
 				new Point(-5f, 10f)
 			});
-		
+
+		Assert.assertEquals(false, polygon.contains(0f, 0f));
 		Assert.assertEquals(true, polygon.contains(0f, 5f));
 		Assert.assertEquals(false, polygon.contains(15f, 5f));
-		
+
+		Assert.assertEquals(false, polygon.contains(new Vector2(0f,0f)));
 		Assert.assertEquals(true, polygon.contains(new Vector2(0f, 5f)));
 		Assert.assertEquals(false, polygon.contains(new Vector2(15f, 5f)));
 		
@@ -738,6 +740,46 @@ public class PolygonTest {
 		Assert.assertEquals(true, polygon.intersects(intersectingRectangle));
 		Assert.assertEquals(true, polygon.intersects(onLineIntersectingRectangle));
 		Assert.assertEquals(false, polygon.intersects(nonIntersectingRectangle));
+	}
+
+	@Test
+	public void testIntersectsIgnoringEdgesRectangle() {
+		Polygon polygon = new Polygon(new Point [] {
+				new Point(0f, 0f),
+				new Point(10f, 0f),
+				new Point(10f, 10f),
+				new Point(0f, 10f)
+		});
+
+		Rectangle intersectingRectangle = new Rectangle(-5f, -5f, 10f, 10f);
+		Rectangle onLineIntersectingRectangle = new Rectangle(-5f, -5f, 10f, 5f);
+		Rectangle nonIntersectingRectangle = new Rectangle(100f, 100f, 10f, 10f);
+
+		Assert.assertEquals(true, polygon.intersectsIgnoringEdges(intersectingRectangle));
+		Assert.assertEquals(false, polygon.intersectsIgnoringEdges(onLineIntersectingRectangle));
+		Assert.assertEquals(false, polygon.intersectsIgnoringEdges(nonIntersectingRectangle));
+	}
+
+	@Test
+	public void testIntersectsIgnorin58gEdgesRectangleCircle() {
+		Polygon polygon = new Polygon(new Point [] {
+				new Point(0f, 0f),
+				new Point(10f, 0f),
+				new Point(10f, 10f),
+				new Point(0f, 10f)
+		});
+
+		Circle intersectingCircle = new Circle(8,8,8);
+		Circle onLineIntersectingCircle = new Circle(15, 5, 5);
+		Circle nonIntersectingCircle = new Circle(20, 5, 5);
+
+		Assert.assertEquals(true, polygon.intersectsIgnoringEdges(intersectingCircle));
+		Assert.assertEquals(false, polygon.intersectsIgnoringEdges(onLineIntersectingCircle));
+		Assert.assertEquals(false, polygon.intersectsIgnoringEdges(nonIntersectingCircle));
+
+		Assert.assertEquals(true, intersectingCircle.intersectsIgnoringEdges(polygon));
+		Assert.assertEquals(false, onLineIntersectingCircle.intersectsIgnoringEdges(polygon));
+		Assert.assertEquals(false, nonIntersectingCircle.intersectsIgnoringEdges(polygon));
 	}
 	
 	@Test

--- a/core/src/test/java/org/mini2Dx/core/geom/RectangleTest.java
+++ b/core/src/test/java/org/mini2Dx/core/geom/RectangleTest.java
@@ -361,6 +361,34 @@ public class RectangleTest {
 	}
 
 	@Test
+	public void testIntersectsIgnoringEdgeOverlap() {
+		rectangle1 = new Rectangle(0, 0, 50, 50);
+		rectangle2 = new Rectangle(49, 0, 50f, 50f);
+
+		Assert.assertTrue(rectangle1.intersectsIgnoringEdges(rectangle2));
+
+		rectangle2.setXY(49, 0);
+		Assert.assertTrue(rectangle1.intersectsIgnoringEdges(rectangle2));
+		rectangle2.setXY(50, 0);
+		Assert.assertFalse(rectangle1.intersectsIgnoringEdges(rectangle2));
+
+		rectangle2.setXY(-49, 0);
+		Assert.assertTrue(rectangle1.intersectsIgnoringEdges(rectangle2));
+		rectangle2.setXY(-50, 0);
+		Assert.assertFalse(rectangle1.intersectsIgnoringEdges(rectangle2));
+
+		rectangle2.setXY(0, 49);
+		Assert.assertTrue(rectangle1.intersectsIgnoringEdges(rectangle2));
+		rectangle2.setXY(0, 50);
+		Assert.assertFalse(rectangle1.intersectsIgnoringEdges(rectangle2));
+
+		rectangle2.setXY(0, -49);
+		Assert.assertTrue(rectangle1.intersectsIgnoringEdges(rectangle2));
+		rectangle2.setXY(0, -50);
+		Assert.assertFalse(rectangle1.intersectsIgnoringEdges(rectangle2));
+	}
+
+	@Test
 	public void testLerp() {
 		rectangle1 = new Rectangle(0, 0, 50, 50);
 		rectangle2 = new Rectangle(50, 50, 100f, 100f);


### PR DESCRIPTION
Added  methods to  region quad tree to get elements within area, ignoring elements only touching area edge.
Added methods to shape to get intersection of shapes ignoring if only edges overlap.
Updated test cases.