### PR TITLE
Make MonoGame sprite tint behavior consistent with libgdx

### DIFF
--- a/monogame/Graphics/MonoGameSprite.cs
+++ b/monogame/Graphics/MonoGameSprite.cs
@@ -30,10 +30,12 @@ namespace monogame.Graphics
     {
 
         private float _x, _y, _width, _height, _originX, _originY, _rotation, _scaleX = 1, _scaleY = 1, _90degRotation;
-        private Color _tint = new MonoGameColor(Microsoft.Xna.Framework.Color.White);
+        internal Microsoft.Xna.Framework.Color _actualTint = Microsoft.Xna.Framework.Color.White;
+        private Color _tint;
 
         public MonoGameSprite()
         {
+            _tint = new MonoGameColor(_actualTint);
             setOriginCenter_EFE09FC0();
         }
 
@@ -44,6 +46,7 @@ namespace monogame.Graphics
         public MonoGameSprite(Texture texture, int srcX, int srcY, int srcWidth, int srcHeight) : base(texture, srcX,
             srcY, srcWidth, srcHeight)
         {
+            _tint = new MonoGameColor(_actualTint);
             setBounds_C2EDAFC0(srcX, srcY, srcWidth, srcHeight);
             setOriginCenter_EFE09FC0();
         }
@@ -54,6 +57,7 @@ namespace monogame.Graphics
 
         public MonoGameSprite(TextureRegion region, int x, int y, int width, int height) : base(region, x, y, width, height)
         {
+            _tint = new MonoGameColor(_actualTint);
             setFlip_62FCD310(region.isFlipX_FBE0B2A4(), region.isFlipY_FBE0B2A4());
             setBounds_C2EDAFC0(x, y, width, height);
             setOriginCenter_EFE09FC0();
@@ -66,6 +70,7 @@ namespace monogame.Graphics
         public MonoGameSprite(TextureAtlasRegion region, int x, int y, int width, int height) : base(region, x, y,
             width, height)
         {
+            _tint = new MonoGameColor(_actualTint);
             if (region.getRotatedPackedHeight_FFE0B8F0() != region.getRegionHeight_0EE0D08D())
             {
                 rotate90_AA5A2C66(false);
@@ -269,7 +274,7 @@ namespace monogame.Graphics
         public void setTint_24D51C91(Color c)
         {
             var oldAlpha = getAlpha_FFE0B8F0();
-            _tint = c;
+            _tint.set_F18CABCA(c);
             setAlpha_97413DCA(oldAlpha);
         }
 
@@ -280,8 +285,8 @@ namespace monogame.Graphics
 
         public void setAlpha_97413DCA(float alpha)
         {
-            _tint.multiply_DF74E9CF(1f, 1f, 1f, 0f);
-            _tint.add_DF74E9CF(0, 0, 0, alpha);
+            _tint.setA_97413DCA(alpha);
+            _actualTint.PackedValue = ((MonoGameColor) _tint)._color.PackedValue;
         }
     }
 }

--- a/monogame/MonoGameGraphics.cs
+++ b/monogame/MonoGameGraphics.cs
@@ -403,13 +403,8 @@ namespace monogame
             fillPolygon_C74D914F(shape.getPolygon_A507AF13().getVertices_9E7A8229(), shape.getPolygon_A507AF13().getTriangles_78095B83().toArray_917A6DB2());
         }
 
-        public void drawSprite_615359F5(Sprite sprite)
+        private void _internalDrawSprite(Sprite sprite, float x, float y, Microsoft.Xna.Framework.Color tint)
         {
-            drawSprite_2D162465(sprite, sprite.getX_FFE0B8F0(), sprite.getY_FFE0B8F0());
-        }
-
-        public void drawSprite_2D162465(Sprite sprite, float x, float y)
-        {     
             beginRendering();   
             if (sprite.getTexture_D75719FD().getUAddressMode_F8C501D6() != _currentUMode || sprite.getTexture_D75719FD().getVAddressMode_F8C501D6() != _currentVMode)
             {
@@ -428,22 +423,31 @@ namespace monogame
             _sharedOriginVector.Y = sprite.getOriginY_FFE0B8F0();
             _sharedScaleVector.X = sprite.getScaleX_FFE0B8F0();
             _sharedScaleVector.Y = sprite.getScaleY_FFE0B8F0();
+            
+            _spriteBatch.Draw(((MonoGameTexture) sprite.getTexture_D75719FD()).texture2D, _sharedPositionVector,
+                _sharedSourceRectangle, tint,
+                MonoGameMathsUtil.degreeToRadian(((MonoGameSprite) sprite).getTotalRotation()),
+                _sharedOriginVector, _sharedScaleVector, (sprite.isFlipX_FBE0B2A4() ? SpriteEffects.FlipHorizontally : SpriteEffects.None) |
+                                                         (sprite.isFlipY_FBE0B2A4() ? SpriteEffects.FlipVertically : SpriteEffects.None), 0f);
+        }
 
+        public void drawSprite_615359F5(Sprite sprite)
+        {
             //if tint is white use sprite tint
             Microsoft.Xna.Framework.Color drawColor;
             if (_tint.Equals(Microsoft.Xna.Framework.Color.White))
             {
-                drawColor = ((MonoGameColor)sprite.getTint_F0D7D9CF())._color;
+                drawColor = ((MonoGameSprite)sprite)._actualTint;
             } else
             {
                 drawColor = _tint;
             }
-            
-            _spriteBatch.Draw(((MonoGameTexture) sprite.getTexture_D75719FD()).texture2D, _sharedPositionVector,
-                _sharedSourceRectangle, drawColor,
-                MonoGameMathsUtil.degreeToRadian(((MonoGameSprite) sprite).getTotalRotation()),
-                _sharedOriginVector, _sharedScaleVector, (sprite.isFlipX_FBE0B2A4() ? SpriteEffects.FlipHorizontally : SpriteEffects.None) |
-                (sprite.isFlipY_FBE0B2A4() ? SpriteEffects.FlipVertically : SpriteEffects.None), 0f);
+            _internalDrawSprite(sprite, sprite.getX_FFE0B8F0(), sprite.getY_FFE0B8F0(), drawColor);
+        }
+
+        public void drawSprite_2D162465(Sprite sprite, float x, float y)
+        {     
+            _internalDrawSprite(sprite, x, y, _tint);
         }
 
         internal void drawTexture(MonoGameTexture texture, float x, float y, int srcX, int srcY, int srcWidth,
@@ -850,6 +854,7 @@ namespace monogame
         public void setFont_6B60E80F(GameFont font)
         {
             _font = font;
+            _font.setColor_24D51C91(_setColor);
         }
 
         public Shader getShader_364FDDC3()


### PR DESCRIPTION
Libgdx isn't influenced by changes to the color object passed to Sprite.setTint
Libgdx ignores the sprites tint only when g.drawSprite(Sprite, float, float) is called