### PR TITLE
Cut in half objects generated by proxy listeners in geom

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,9 +19,17 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
+    - uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: r22
     - name: Build with Gradle
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 21
         emulator-build: 7425822
-        script: ./gradlew build -x :mini2Dx-uats-libgdx-android:check -x :mini2Dx-uats-libgdx-android:validateSigningDebug -x :mini2Dx-uats-libgdx-android:packageDebug
+        script: |
+          ln -s ${ANDROID_HOME}/build-tools/31.0.0/d8 ${ANDROID_HOME}/build-tools/31.0.0/dx
+          ln -s ${ANDROID_HOME}/build-tools/31.0.0/lib/d8.jar ${ANDROID_HOME}/build-tools/31.0.0/lib/dx.jar
+          ./gradlew build -x :mini2Dx-uats-libgdx-android:check -x :mini2Dx-uats-libgdx-android:validateSigningDebug -x :mini2Dx-uats-libgdx-android:packageDebug
+

--- a/core/src/main/java/org/mini2Dx/core/geom/Rectangle.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Rectangle.java
@@ -18,9 +18,7 @@ package org.mini2Dx.core.geom;
 import org.mini2Dx.core.Geometry;
 import org.mini2Dx.core.Graphics;
 import org.mini2Dx.core.util.Lerper;
-import org.mini2Dx.gdx.math.MathUtils;
 import org.mini2Dx.gdx.math.Vector2;
-import org.w3c.dom.css.Rect;
 
 /**
  * Implements a rectangle.
@@ -44,6 +42,7 @@ public class Rectangle extends Shape {
 	};
 
 	final Polygon polygon;
+	final ProxyListeners proxyListeners = new ProxyListeners();
 	private float width, height;
 	
 	/**
@@ -99,18 +98,8 @@ public class Rectangle extends Shape {
 	}
 
 	private void initProxyListeners() {
-		polygon.addPostionChangeListener(new PositionChangeListener<Positionable>() {
-			@Override
-			public void positionChanged(Positionable moved) {
-				Rectangle.this.notifyPositionChangeListeners();
-			}
-		});
-		polygon.addSizeChangeListener(new SizeChangeListener<Sizeable>() {
-			@Override
-			public void sizeChanged(Sizeable changed) {
-				Rectangle.this.notifySizeChangeListeners();
-			}
-		});
+		polygon.addPostionChangeListener(proxyListeners);
+		polygon.addSizeChangeListener(proxyListeners);
 	}
 
 	@Override
@@ -571,5 +560,18 @@ public class Rectangle extends Shape {
 		if (Float.floatToIntBits(getRotation()) != Float.floatToIntBits(other.getRotation()))
 			return false;
 		return true;
+	}
+
+	private class ProxyListeners implements PositionChangeListener<Positionable>, SizeChangeListener<Sizeable> {
+
+		@Override
+		public void positionChanged(Positionable moved) {
+			notifyPositionChangeListeners();
+		}
+
+		@Override
+		public void sizeChanged(Sizeable changed) {
+			notifySizeChangeListeners();
+		}
 	}
 }

--- a/core/src/main/java/org/mini2Dx/core/geom/RegularPolygon.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/RegularPolygon.java
@@ -28,6 +28,7 @@ public class RegularPolygon extends Shape {
 	private final float rotationSymmetry;
 	private final int totalSides;
 	private final Point center;
+	final ProxyListeners proxyListeners = new ProxyListeners();
 
 	private Polygon polygon;
 	private float radius;
@@ -78,18 +79,8 @@ public class RegularPolygon extends Shape {
 	}
 
 	private void initProxyListeners() {
-		polygon.addPostionChangeListener(new PositionChangeListener<Positionable>() {
-			@Override
-			public void positionChanged(Positionable moved) {
-				RegularPolygon.this.notifyPositionChangeListeners();
-			}
-		});
-		polygon.addSizeChangeListener(new SizeChangeListener<Sizeable>() {
-			@Override
-			public void sizeChanged(Sizeable changed) {
-				RegularPolygon.this.notifySizeChangeListeners();
-			}
-		});
+		polygon.addPostionChangeListener(proxyListeners);
+		polygon.addSizeChangeListener(proxyListeners);
 	}
 
 	@Override
@@ -446,5 +437,18 @@ public class RegularPolygon extends Shape {
 		} else if (!polygon.equals(other.polygon))
 			return false;
 		return true;
+	}
+
+	private class ProxyListeners implements PositionChangeListener<Positionable>, SizeChangeListener<Sizeable> {
+
+		@Override
+		public void positionChanged(Positionable moved) {
+			notifyPositionChangeListeners();
+		}
+
+		@Override
+		public void sizeChanged(Sizeable changed) {
+			notifySizeChangeListeners();
+		}
 	}
 }

--- a/core/src/main/java/org/mini2Dx/core/geom/Triangle.java
+++ b/core/src/main/java/org/mini2Dx/core/geom/Triangle.java
@@ -26,6 +26,7 @@ public class Triangle extends Shape {
 	private static final int TOTAL_SIDES = 3;
 
 	final Polygon polygon;
+	final ProxyListeners proxyListeners = new ProxyListeners();
 
 	/**
 	 * Constructor
@@ -79,18 +80,8 @@ public class Triangle extends Shape {
 	}
 
 	private void initProxyListeners() {
-		polygon.addPostionChangeListener(new PositionChangeListener<Positionable>() {
-			@Override
-			public void positionChanged(Positionable moved) {
-				Triangle.this.notifyPositionChangeListeners();
-			}
-		});
-		polygon.addSizeChangeListener(new SizeChangeListener<Sizeable>() {
-			@Override
-			public void sizeChanged(Sizeable changed) {
-				Triangle.this.notifySizeChangeListeners();
-			}
-		});
+		polygon.addPostionChangeListener(proxyListeners);
+		polygon.addSizeChangeListener(proxyListeners);
 	}
 
 	@Override
@@ -367,5 +358,18 @@ public class Triangle extends Shape {
 		} else if (!polygon.equals(other.polygon))
 			return false;
 		return true;
+	}
+
+	private class ProxyListeners implements PositionChangeListener<Positionable>, SizeChangeListener<Sizeable> {
+
+		@Override
+		public void positionChanged(Positionable moved) {
+			notifyPositionChangeListeners();
+		}
+
+		@Override
+		public void sizeChanged(Sizeable changed) {
+			notifySizeChangeListeners();
+		}
 	}
 }

--- a/libgdx-android/build.gradle
+++ b/libgdx-android/build.gradle
@@ -1,4 +1,5 @@
 android {
+    ndkVersion "22.1.7171670"
     compileSdkVersion 21
 	defaultConfig {
 		minSdkVersion 21

--- a/uats-libgdx-android/build.gradle
+++ b/uats-libgdx-android/build.gradle
@@ -1,4 +1,5 @@
 android {
+    ndkVersion "22.1.7171670"
     compileSdkVersion 21
     defaultConfig {
         testApplicationId "org.mini2Dx.uats.android.test"


### PR DESCRIPTION
Original plan was to make the classes implement PositionChangeListener and SizeChangeListener but that would break api because classes inheriting from Rectangle, Triangle or RegularPolygon would not be able to implement {Position,Size}ChangeListener anymore