### PR TITLE
Grid UI Navigation moving to next available element

### DIFF
--- a/ui/src/main/java/org/mini2Dx/ui/navigation/GridUiNavigation.java
+++ b/ui/src/main/java/org/mini2Dx/ui/navigation/GridUiNavigation.java
@@ -62,7 +62,7 @@ public class GridUiNavigation implements UiNavigation {
 		return false;
 	}
 	
-	private int getIndex(int x, int y) {
+	int getIndex(int x, int y) {
 		return (y * columns) + x;
 	}
 
@@ -324,11 +324,34 @@ public class GridUiNavigation implements UiNavigation {
 		int tempCursorX = cursorX;
 		while ((cursorX + direction) >= 0 && (cursorX + direction) < getTotalColumns()){
 			cursorX += direction;
+			//after moving in a direction, try moving up/down to closest none null element
+			if (navigation.get(getIndex(cursorX, cursorY)) == null){
+				if (findClosestItemVertically()){
+					return;
+				}
+			}
 			if (navigation.get(getIndex(cursorX, cursorY)) != null){
 				return;
 			}
 		}
 		cursorX = tempCursorX;
+	}
+
+	private boolean findClosestItemVertically() {
+		int tempY = cursorY;
+		int direction = 1;
+		while (tempY + direction < getTotalRows() || tempY - direction >= 0){
+			if (tempY + direction < getTotalRows() && getIndex(cursorX, tempY + direction) < navigation.size && navigation.get(getIndex(cursorX, tempY + direction)) != null){
+				cursorY = tempY + direction;
+				return true;
+			}
+			if (tempY - direction >= 0 && navigation.get(getIndex(cursorX, tempY - direction)) != null){
+				cursorY = tempY - direction;
+				return true;
+			}
+			direction += 1;
+		}
+		return false;
 	}
 
 	int getNavigationSize(){

--- a/ui/src/test/java/org/mini2Dx/ui/navigation/GridUiNavigationTest.java
+++ b/ui/src/test/java/org/mini2Dx/ui/navigation/GridUiNavigationTest.java
@@ -263,8 +263,47 @@ public class GridUiNavigationTest {
 		}
 
 		navigation.updateCursor(navigationElements[2][1].getId());
-		navigation.set(1, 1, null);
+
+		//set entire middle column to null elements to move over
+		for (int i = 0; i < ROWS; i++) {
+			navigation.set(1, i, null);
+		}
+
 		Assert.assertEquals(navigationElements[0][1], navigation.navigate(Keys.LEFT));
+	}
+
+	@Test
+	public void testNavigateLeftClosestVerticalElementDownwards(){
+		Button[][] navigationElements =  new Button[COLUMNS][ROWS];
+		for(int x = 0; x < COLUMNS; x++) {
+			for(int y = 0; y < ROWS; y++) {
+				navigationElements[x][y] = new Button("button-" + x + "," + y);
+				navigation.set(x, y, navigationElements[x][y]);}
+		}
+
+		navigation.updateCursor(navigationElements[2][1].getId());
+
+		navigation.set(1, 0, null);
+		navigation.set(1, 1, null);
+
+		Assert.assertEquals(navigationElements[1][2], navigation.navigate(Keys.LEFT));
+	}
+
+	@Test
+	public void testNavigateLeftClosestVerticalElementUpwards(){
+		Button[][] navigationElements =  new Button[COLUMNS][ROWS];
+		for(int x = 0; x < COLUMNS; x++) {
+			for(int y = 0; y < ROWS; y++) {
+				navigationElements[x][y] = new Button("button-" + x + "," + y);
+				navigation.set(x, y, navigationElements[x][y]);}
+		}
+
+		navigation.updateCursor(navigationElements[2][1].getId());
+
+		navigation.set(1, 1, null);
+		navigation.set(1, 2, null);
+
+		Assert.assertEquals(navigationElements[1][0], navigation.navigate(Keys.LEFT));
 	}
 
 	@Test
@@ -277,8 +316,71 @@ public class GridUiNavigationTest {
 		}
 
 		navigation.updateCursor(navigationElements[0][1].getId());
-		navigation.set(1, 1, null);
+
+		for (int i = 0; i < ROWS; i++) {
+			navigation.set(1, i, null);
+		}
 		Assert.assertEquals(navigationElements[2][1], navigation.navigate(Keys.RIGHT));
+	}
+
+	@Test
+	public void testNavigateRightClosestVerticalElementDownwards(){
+		Button[][] navigationElements =  new Button[COLUMNS][ROWS];
+		for(int x = 0; x < COLUMNS; x++) {
+			for(int y = 0; y < ROWS; y++) {
+				navigationElements[x][y] = new Button("button-" + x + "," + y);
+				navigation.set(x, y, navigationElements[x][y]);}
+		}
+
+		navigation.updateCursor(navigationElements[0][1].getId());
+
+		navigation.set(1, 0, null);
+		navigation.set(1, 1, null);
+
+		Assert.assertEquals(navigationElements[1][2], navigation.navigate(Keys.RIGHT));
+	}
+
+	@Test
+	public void testNavigateRightClosestVerticalElementUpwards(){
+		Button[][] navigationElements =  new Button[COLUMNS][ROWS];
+		for(int x = 0; x < COLUMNS; x++) {
+			for(int y = 0; y < ROWS; y++) {
+				navigationElements[x][y] = new Button("button-" + x + "," + y);
+				navigation.set(x, y, navigationElements[x][y]);}
+		}
+
+		navigation.updateCursor(navigationElements[0][1].getId());
+
+		navigation.set(1, 1, null);
+		navigation.set(1, 2, null);
+
+		Assert.assertEquals(navigationElements[1][0], navigation.navigate(Keys.RIGHT));
+	}
+
+	@Test
+	public void testNavigateRightClosestVerticalElementUpwardsUnevenGridSplit(){
+		int cols = 2;
+		int rows = 3;
+
+		GridUiNavigation gridUiNavigation = new GridUiNavigation(cols);
+
+
+		Button[][] navigationElements =  new Button[cols][rows];
+		for(int x = 0; x < cols; x++) {
+			for(int y = 0; y < rows; y++) {
+				if (x == 1 && y == 1){
+					break;
+				}
+				navigationElements[x][y] = new Button("button-" + x + "," + y);
+				gridUiNavigation.set(x, y, navigationElements[x][y]);
+			}
+		}
+
+		gridUiNavigation.updateCursor(navigationElements[0][1].getId());
+
+		gridUiNavigation.set(1, 1, null);
+
+		Assert.assertEquals(navigationElements[1][0], gridUiNavigation.navigate(Keys.RIGHT));
 	}
 
 	@Test
@@ -306,8 +408,13 @@ public class GridUiNavigationTest {
 		}
 
 		navigation.updateCursor(navigationElements[0][0].getId());
-		navigation.set(1, 0, null);
-		navigation.set(2, 0, null);
+
+		//set both rows to null so there is nothing to move to
+		for (int i = 0; i < ROWS; i++) {
+			navigation.set(1, i, null);
+			navigation.set(2, i, null);
+		}
+
 		Assert.assertEquals(navigationElements[0][0], navigation.navigate(Keys.RIGHT));
 	}
 


### PR DESCRIPTION
Updated grid UI, when moving horizontally, to move to a valid element in the next column if same row isn't valid.
In case where entire neighbouring row is not valid, navigation will stay on the current element