### PR TITLE
Fixed delta always being set to zero

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@
 - Optimised shape rendering under LibGDX
 - Improvements to UiContainer input handling
 - Fixed UI input when rendering to a viewport
+- Fixed delta always being set to zero before game container update methods invoked (only affecting Android)
 
 [1.9.10]
 - Update to latest RoboVM to support iOS 12

--- a/libgdx-android/src/main/java/com/badlogic/gdx/backends/android/AndroidMini2DxGraphics.java
+++ b/libgdx-android/src/main/java/com/badlogic/gdx/backends/android/AndroidMini2DxGraphics.java
@@ -54,10 +54,6 @@ public class AndroidMini2DxGraphics extends AndroidGraphics {
 		final AndroidMini2DxConfig config = (AndroidMini2DxConfig) super.config;
 
 		long time = System.nanoTime();
-		deltaTime = (time - lastFrameTime) / 1000000000.0f;
-		lastFrameTime = time;
-		Mdx.platformUtils.markFrameBegin();
-
 		// After pause deltaTime can have somewhat huge value that destabilizes the mean, so let's cut it off
 		if (!resume) {
 			deltaTime = (time - lastFrameTime) / 1000000000.0f;
@@ -65,6 +61,7 @@ public class AndroidMini2DxGraphics extends AndroidGraphics {
 			deltaTime = 0;
 		}
 		lastFrameTime = time;
+		Mdx.platformUtils.markFrameBegin();
 
 		boolean lrunning = false;
 		boolean lpause = false;


### PR DESCRIPTION
Fixed delta always being set to zero before game container update methods invoked (only affecting Android)